### PR TITLE
Redirect the root url to gallery to avoid 404

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from src.interfaces import views
 
 urlpatterns = [
+    path("", RedirectView.as_view(pattern_name="gallery"), name="root"),
     path("images/", views.gallery_view, name="gallery"),
     path("images/results/", views.gallery_results_view, name="gallery-results"),
     path("images/file/<int:image_id>/", views.image_file_view, name="image-file"),

--- a/tests/functional/test_root_redirect.py
+++ b/tests/functional/test_root_redirect.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.django_db
+class TestRootRedirect:
+    def test_root_redirects_to_gallery(self, client):
+        response = client.get("/")
+
+        assert response.status_code == 302
+        assert response["Location"] == "/images/"


### PR DESCRIPTION
Previously, the root URL (/) had no registered route. When make run launched the dev server and a browser (or health check) hit /, Django found no matching URL pattern and returned a 404.

The fix registers "" (i.e. /) and maps it to Django's built-in RedirectView, which issues a redirect to the gallery named URL (/images/). Now visiting the root URL redirects to the gallery instead of returning 404.