### PR TITLE
Test CI workflow

### DIFF
--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -1,0 +1,28 @@
+name: Architecture
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-imports:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Set up settings
+        run: cp src/config/settings.py.sample src/config/settings.py
+
+      - name: Check layered architecture
+        run: lint-imports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install system dependencies
+        run: sudo apt-get install -y libimage-exiftool-perl
+
       - name: Install dependencies
         run: |
           pip install -r requirements.txt -r requirements-dev.txt


### PR DESCRIPTION
**What**
Adds a GitHub Actions workflow that runs the full test suite with pytest on every push and pull request targeting main. The workflow spins up a PostgreSQL 16 service with the credentials matching the project's settings, installs exiftool as a system dependency, and installs all Python dependencies before running tests.
Adds a second GitHub Actions workflow that checks the layered architecture using lint-imports, ensuring no import contract violations are introduced.
**How to use**
Both checks are configured as required status checks on main via branch protection rules, so a PR cannot be merged unless both pass.