### PR TITLE
Feat/drag and drop upload

### DIFF
--- a/.github/workflows/lint-imports.yml
+++ b/.github/workflows/lint-imports.yml
@@ -2,7 +2,7 @@ name: Architecture
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'feat/**']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -2,7 +2,7 @@ name: Migrations
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'feat/**']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'feat/**']
   pull_request:
     branches: [main]
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ scripts/
 
 # Investigation notes
 investigation/
+
+# Imports folder
+imports/

--- a/src/config/settings.py.sample
+++ b/src/config/settings.py.sample
@@ -51,7 +51,7 @@ CAMERA_RETRY_BACKOFF_S:     float = 0.15   # base back-off; doubles each retry (
 THUMBNAIL_CACHE_DIR = BASE_DIR / "thumbnail_cache"  # filesystem directory where generated thumbnails are cached
 IMAGE_IMPORT_DIR = BASE_DIR / "imports"  # internal directory where web-uploaded images are stored (not user-configurable)
 IMAGE_IMPORT_DIR.mkdir(exist_ok=True)
-IMAGE_IMPORT_MAX_FILES = 50  # max files per web upload batch; use the CLI for larger imports
+IMAGE_IMPORT_MAX_FILES = 50  # max files when using web upload, keep using CLI for larger imports
 
 TEMPLATES = [
     {

--- a/src/config/settings.py.sample
+++ b/src/config/settings.py.sample
@@ -46,6 +46,9 @@ CAMERA_INTER_SLOT_DELAY_S:  float = 0.05   # pause between slot cursor changes
 CAMERA_MAX_RETRIES:         int   = 3      # attempts per operation before giving up
 CAMERA_RETRY_BACKOFF_S:     float = 0.15   # base back-off; doubles each retry (0.15 s, 0.30 s, …)
 THUMBNAIL_CACHE_DIR = BASE_DIR / "thumbnail_cache"  # filesystem directory where generated thumbnails are cached
+IMAGE_IMPORT_DIR = BASE_DIR / "imports"  # internal directory where web-uploaded images are stored (not user-configurable)
+IMAGE_IMPORT_DIR.mkdir(exist_ok=True)
+IMAGE_IMPORT_MAX_FILES = 50  # max files per web upload batch; use the CLI for larger imports
 
 TEMPLATES = [
     {

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,10 +1,13 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from src.interfaces import views
 
 urlpatterns = [
+    path("", RedirectView.as_view(pattern_name="gallery"), name="root"),
     path("images/", views.gallery_view, name="gallery"),
     path("images/results/", views.gallery_results_view, name="gallery-results"),
+    path("images/upload/", views.upload_images, name="image-upload"),
     path("images/file/<int:image_id>/", views.image_file_view, name="image-file"),
     path("images/<int:image_id>/", views.image_detail_view, name="image-detail"),
     path("images/<int:image_id>/set-rating/", views.set_image_rating_view, name="image-set-rating"),

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -820,7 +820,7 @@
         resultsEl.innerHTML = html;
       })
       .catch(function () {
-        resultsEl.innerHTML = '<span class="import-tag import-tag--error">Upload failed. Check server logs.</span>';
+        resultsEl.innerHTML = '<span class="import-tag import-tag--error">A server error occurred. Please try again.</span>';
       });
     }
   }());

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -299,6 +299,82 @@
       padding: 0.1rem 0.4rem;
     }
 
+
+    /* --- Import zone --- */
+    .import-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.35rem 0.75rem;
+      border: 1.5px solid #d1d5db;
+      border-radius: 6px;
+      background: #fff;
+      font-size: 0.85rem;
+      color: #555;
+      cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .import-btn:hover { border-color: #f97316; color: #f97316; }
+
+    .import-panel {
+      background: #fafafa;
+      border-bottom: 1px solid #e0e0e0;
+      padding: 1rem 2rem;
+      flex-shrink: 0;
+    }
+    .import-panel[hidden] { display: none; }
+
+    .drop-zone {
+      border: 2px dashed #d1d5db;
+      border-radius: 8px;
+      padding: 2rem;
+      text-align: center;
+      color: #888;
+      font-size: 0.9rem;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+      position: relative;
+    }
+    .drop-zone.drag-over {
+      border-color: #f97316;
+      background: #fff7ed;
+      color: #f97316;
+    }
+    .drop-zone input[type="file"] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+
+    .import-results {
+      margin-top: 0.75rem;
+      font-size: 0.85rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      align-items: center;
+    }
+    .import-tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.8rem;
+    }
+    .import-tag--ok     { background: #d1fae5; color: #065f46; }
+    .import-tag--skip   { background: #fef3c7; color: #92400e; }
+    .import-tag--error  { background: #fee2e2; color: #7f1d1d; }
+
+    .import-spinner {
+      display: inline-block;
+      width: 1rem; height: 1rem;
+      border: 2px solid #e0e0e0;
+      border-top-color: #f97316;
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+      vertical-align: middle;
+      margin-right: 0.4rem;
+    }
+
     .no-results {
       grid-column: 1 / -1;
       color: #888;
@@ -457,13 +533,7 @@
         hx-trigger="change"
         hx-target="#gallery-results"
         hx-push-url="true">
-    <div class="filter-group">
-      <label class="rating-toggle" for="rating-first-toggle">
-        <input type="checkbox" id="rating-first-toggle">
-        Sort by rating
-      </label>
-      <input type="hidden" name="rating_first" id="rating-first-input" value="{{ rating_first }}">
-    </div>
+    <input type="hidden" name="rating_first" id="rating-first-input" value="{{ rating_first }}">
     {% include "images/_recipe_filter.html" %}
     {% include "images/_sidebar_filters.html" %}
   </form>
@@ -472,6 +542,25 @@
 <main class="main">
   <div class="gallery-header">
     <h1>Images</h1>
+    <div style="display:flex;align-items:center;gap:1rem;">
+      <button class="import-btn" id="import-toggle-btn" type="button">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+        Import
+      </button>
+      <label class="rating-toggle" for="rating-first-toggle">
+        <input type="checkbox" id="rating-first-toggle">
+        Sort by rating
+      </label>
+    </div>
+  </div>
+
+  <div class="import-panel" id="import-panel" hidden>
+    <div class="drop-zone" id="drop-zone">
+      <input type="file" id="file-input" accept=".jpg,.jpeg" multiple>
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#ccc" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="display:block;margin:0 auto 0.5rem"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+      Drop Fujifilm JPEGs here, or click to select
+    </div>
+    <div class="import-results" id="import-results" hidden></div>
   </div>
   <div class="gallery-scroll">
     <div id="gallery-results">
@@ -667,6 +756,75 @@
     if (e.key === 'ArrowLeft') { var btn = overlay.querySelector('.detail-nav-prev'); if (btn) btn.click(); }
     if (e.key === 'ArrowRight') { var btn = overlay.querySelector('.detail-nav-next'); if (btn) btn.click(); }
   });
+  // --- Drag & drop import ---
+  (function () {
+    var toggleBtn  = document.getElementById('import-toggle-btn');
+    var panel      = document.getElementById('import-panel');
+    var dropZone   = document.getElementById('drop-zone');
+    var fileInput  = document.getElementById('file-input');
+    var resultsEl  = document.getElementById('import-results');
+    var uploadUrl  = '{% url "image-upload" %}';
+    var csrfToken  = '{{ csrf_token }}';
+
+    toggleBtn.addEventListener('click', function () {
+      panel.hidden = !panel.hidden;
+      resultsEl.hidden = true;
+      resultsEl.innerHTML = '';
+    });
+
+    ['dragenter', 'dragover'].forEach(function (evt) {
+      dropZone.addEventListener(evt, function (e) {
+        e.preventDefault();
+        dropZone.classList.add('drag-over');
+      });
+    });
+    ['dragleave', 'drop'].forEach(function (evt) {
+      dropZone.addEventListener(evt, function (e) {
+        e.preventDefault();
+        dropZone.classList.remove('drag-over');
+      });
+    });
+
+    dropZone.addEventListener('drop', function (e) { handleFiles(e.dataTransfer.files); });
+    fileInput.addEventListener('change', function () { handleFiles(fileInput.files); fileInput.value = ''; });
+
+    function handleFiles(files) {
+      if (!files || files.length === 0) return;
+      var form = new FormData();
+      Array.from(files).forEach(function (f) { form.append('images', f); });
+
+      resultsEl.hidden = false;
+      resultsEl.innerHTML = '<span class="import-spinner"></span> Importing ' + files.length + ' file(s)\u2026';
+
+      fetch(uploadUrl, {
+        method: 'POST',
+        headers: { 'X-CSRFToken': csrfToken },
+        body: form,
+      })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var html = '';
+        if (data.error) {
+          html = '<span class="import-tag import-tag--error">' + data.error + '</span>';
+        } else {
+          data.processed.forEach(function (name) {
+            html += '<span class="import-tag import-tag--ok">' + name + '</span>';
+          });
+          data.skipped.forEach(function (name) {
+            html += '<span class="import-tag import-tag--skip">Skipped: ' + name + '</span>';
+          });
+          if (data.processed.length > 0) {
+            document.getElementById('filter-form').dispatchEvent(new Event('change'));
+          }
+        }
+        resultsEl.innerHTML = html;
+      })
+      .catch(function () {
+        resultsEl.innerHTML = '<span class="import-tag import-tag--error">Upload failed. Check server logs.</span>';
+      });
+    }
+  }());
+
 </script>
 </body>
 </html>

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -146,6 +146,42 @@ def set_image_rating_view(request, image_id):
     )
 
 
+
+
+@http_decorators.require_POST
+def upload_images(request):
+    uploaded = request.FILES.getlist("images")
+    if not uploaded:
+        return http.JsonResponse({"error": "No files provided"}, status=400)
+
+    if len(uploaded) > settings.IMAGE_IMPORT_MAX_FILES:
+        return http.JsonResponse(
+            {"error": f"Max {settings.IMAGE_IMPORT_MAX_FILES} files per upload. Use the CLI for larger imports."},
+            status=413,
+        )
+
+    import_dir = Path(settings.IMAGE_IMPORT_DIR)
+    processed, skipped = [], []
+
+    for f in uploaded:
+        if not f.name.lower().endswith((".jpg", ".jpeg")):
+            skipped.append(f.name)
+            continue
+        dest = import_dir / f.name
+        if dest.exists():
+            skipped.append(f.name)
+            continue
+        with dest.open("wb") as fp:
+            for chunk in f.chunks():
+                fp.write(chunk)
+        try:
+            image_operations.process_image(image_path=str(dest))
+            processed.append(f.name)
+        except image_operations.NoFilmSimulationError:
+            skipped.append(f.name)
+
+    return http.JsonResponse({"processed": processed, "skipped": skipped})
+
 _NOTABLE_RECIPE_MIN_IMAGES = 50  # recipes with fewer images are hidden unless named or selected
 _SLOT_TO_INDEX = {"C1": 1, "C2": 2, "C3": 3, "C4": 4, "C5": 5, "C6": 6, "C7": 7}
 

--- a/tests/functional/test_upload_images.py
+++ b/tests/functional/test_upload_images.py
@@ -1,0 +1,100 @@
+import io
+from pathlib import Path
+
+import pytest
+from django.test import override_settings
+
+from src.data.models import Image
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "images"
+FUJIFILM_JPEG = FIXTURES_DIR / "XS105026.JPG"
+
+
+@pytest.mark.django_db
+class TestUploadImagesView:
+
+    def test_rejects_get_requests(self, client, tmp_path):
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            response = client.get("/images/upload/")
+        assert response.status_code == 405
+
+    def test_returns_400_when_no_files(self, client, tmp_path):
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            response = client.post("/images/upload/")
+        assert response.status_code == 400
+        assert "error" in response.json()
+
+    def test_processes_valid_fujifilm_jpeg(self, client, tmp_path):
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            with FUJIFILM_JPEG.open("rb") as f:
+                response = client.post("/images/upload/", {"images": f})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert FUJIFILM_JPEG.name in data["processed"]
+        assert data["skipped"] == []
+        assert Image.objects.filter(filename=FUJIFILM_JPEG.name).exists()
+
+    def test_skips_non_jpeg_files(self, client, tmp_path):
+        fake_txt = io.BytesIO(b"not an image")
+        fake_txt.name = "notes.txt"
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            response = client.post("/images/upload/", {"images": fake_txt})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["processed"] == []
+        assert "notes.txt" in data["skipped"]
+
+    def test_skips_non_fujifilm_jpeg(self, client, tmp_path):
+        # A valid JPEG header but no Fujifilm EXIF → NoFilmSimulationError
+        minimal_jpeg = io.BytesIO(bytes([0xFF, 0xD8, 0xFF, 0xD9]))
+        minimal_jpeg.name = "other-brand.jpg"
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            response = client.post("/images/upload/", {"images": minimal_jpeg})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "other-brand.jpg" in data["skipped"]
+        assert data["processed"] == []
+
+    def test_saves_file_to_import_dir(self, client, tmp_path):
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            with FUJIFILM_JPEG.open("rb") as f:
+                client.post("/images/upload/", {"images": f})
+
+        assert (tmp_path / FUJIFILM_JPEG.name).exists()
+
+    def test_returns_413_when_too_many_files(self, client, tmp_path):
+        files = [io.BytesIO(b"x") for _ in range(51)]
+        for i, f in enumerate(files):
+            f.name = f"img_{i}.jpg"
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path, IMAGE_IMPORT_MAX_FILES=50):
+            response = client.post("/images/upload/", {"images": files})
+        assert response.status_code == 413
+        assert "error" in response.json()
+
+    def test_skips_already_imported_file(self, client, tmp_path):
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            with FUJIFILM_JPEG.open("rb") as f:
+                client.post("/images/upload/", {"images": f})
+            with FUJIFILM_JPEG.open("rb") as f:
+                response = client.post("/images/upload/", {"images": f})
+
+        data = response.json()
+        assert FUJIFILM_JPEG.name in data["skipped"]
+        assert data["processed"] == []
+        assert len(list(tmp_path.glob("*.JPG"))) == 1
+
+    def test_processes_multiple_files(self, client, tmp_path):
+        jpeg_files = list(FIXTURES_DIR.glob("*.JPG"))[:2]
+        with override_settings(IMAGE_IMPORT_DIR=tmp_path):
+            files = [f.open("rb") for f in jpeg_files]
+            try:
+                response = client.post("/images/upload/", {"images": files})
+            finally:
+                for f in files:
+                    f.close()
+
+        data = response.json()
+        assert len(data["processed"]) + len(data["skipped"]) == len(jpeg_files)


### PR DESCRIPTION
This PR replicate the feature 1/2 of PR #1.

## What?

Adds image import via drag & drop directly from the gallery, as a complement to the existing CLI workflow.

## Why?

The CLI (`process_images_sync`) requires terminal access, which is a friction point for quick imports. This adds a drop zone in the gallery header for uploading Fujifilm JPEGs without leaving the browser.

## How it works

- `POST /images/upload/` saves uploaded files to an internal `imports/` directory and processes them synchronously.
- The upload batch is capped at 50 files (413 response beyond that, with a message pointing to the CLI) to avoid big copies.
- Processed files appear as green tags, skipped files (duplicates, unaccepted format) as orange 

## How to test

1. Start the server (`make run`) and open `/images/`
2. Click **Import** in the header
3. Drop Fujifilm JPEGs onto the zone or click to select files
4. Verify green/orange tags and gallery refresh
5. Drop the same file again and verify it is skipped

## Unit tests
```bash
pytest tests/functional/test_upload_images.py -v
```

*Design note for maintainer*
Uploaded files persist in imports/ folder to allow image_file_view serving from image.filepath. This means imports/ grows unbounded with no automatic cleanup through sessions. A cleaner approach (among others) might be to let the user configure a destination directory rather than imposing imports/. This PR intentionally keeps the scope small and defers that decision, but it might be address.
