### PR TITLE
Feature recipe explorer view

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,9 +1,12 @@
+from django.conf import settings
 from django.urls import path
 from django.views.generic import RedirectView
+from django.views.static import serve as static_serve
 
 from src.interfaces import views
 
 urlpatterns = [
+    path("static/<path:path>", static_serve, {"document_root": settings.STATIC_FILES_DIR}),
     path("", RedirectView.as_view(pattern_name="gallery"), name="root"),
     path("images/", views.gallery_view, name="gallery"),
     path("images/results/", views.gallery_results_view, name="gallery-results"),
@@ -11,6 +14,7 @@ urlpatterns = [
     path("images/<int:image_id>/", views.image_detail_view, name="image-detail"),
     path("images/<int:image_id>/set-rating/", views.set_image_rating_view, name="image-set-rating"),
     path("recipes/", views.recipes_explorer_view, name="recipes-explorer"),
+    path("recipes/partial/results/", views.recipes_explorer_results_view, name="recipes-explorer-partial-results"),
     path("recipes/graph/", views.recipes_graph_view, name="recipes-graph"),
     path("recipes/graph/<int:recipe_id>/", views.recipe_graph_view, name="recipe-graph"),
     path("recipes/<int:recipe_id>/images/", views.recipe_images_view, name="recipe-images"),

--- a/src/domain/recipes/constants.py
+++ b/src/domain/recipes/constants.py
@@ -1,0 +1,25 @@
+# Maps film_simulation field value → logo filename under src/interfaces/static/images/.
+# Keys must exactly match the string values stored in FujifilmRecipe.film_simulation,
+# which are defined by FILM_SIMULATION_TO_PTP in src/data/camera/constants.py.
+FILM_SIM_LOGO: dict[str, str] = {
+    "Provia":               "provia.png",
+    "Velvia":               "velvia.png",
+    "Astia":                "astia.png",
+    "Pro Neg. Hi":          "pro-neg-hi.png",
+    "Pro Neg. Std":         "pro-neg-std.png",
+    "Monochrome STD":       "monochrome.png",
+    "Monochrome Yellow":    "monochrome-ye-filter.png",
+    "Monochrome Red":       "monochrome-r-filter.png",
+    "Monochrome Green":     "monochrome-g-filter.png",
+    "Sepia":                "sepia.png",
+    "Classic Chrome":       "classic-chrome.png",
+    "Acros STD":            "acros.png",
+    "Acros Yellow":         "acros-ye-filter.png",
+    "Acros Red":            "acros-r-filter.png",
+    "Acros Green":          "acros-g-filter.png",
+    "Eterna":               "eterna.png",
+    "Classic Negative":     "classic-neg.png",
+    "Eterna Bleach Bypass": "eterna-bleach-bypass.png",
+    "Nostalgic Negative":   "nostalgic-neg.png",
+    "Reala Ace":            "reala-ace.png",
+}

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -4,10 +4,13 @@ from collections.abc import Mapping, Sequence
 
 import attrs
 from django.core import paginator as django_paginator
-from django.db.models import Case, Count, IntegerField, Max, Min, Value, When
+from django.db import models as db_models
+from django.db.models import Case, Count, IntegerField, Max, Min, OuterRef, Subquery, Value, When
 from django.db.models.functions import TruncMonth
 
 from src.data import models
+from src.domain.images import filter_queries
+from src.domain.recipes.constants import FILM_SIM_LOGO
 from src.domain.images import dataclasses as image_dataclasses
 
 
@@ -371,14 +374,16 @@ class RecipeData:
     white_balance_red: int
     white_balance_blue: int
     image_count: int
-    highlight: object = None       # Decimal | None
-    shadow: object = None          # Decimal | None
-    color: object = None           # Decimal | None
-    sharpness: object = None       # Decimal | None
-    high_iso_nr: object = None     # Decimal | None
-    clarity: object = None         # Decimal | None
-    monochromatic_color_warm_cool: object = None    # Decimal | None
+    highlight: object = None                       # Decimal | None
+    shadow: object = None                          # Decimal | None
+    color: object = None                           # Decimal | None
+    sharpness: object = None                       # Decimal | None
+    high_iso_nr: object = None                     # Decimal | None
+    clarity: object = None                         # Decimal | None
+    monochromatic_color_warm_cool: object = None   # Decimal | None
     monochromatic_color_magenta_green: object = None  # Decimal | None
+    cover_image_id: int | None = None              # most popular image for card background
+    film_sim_logo_filename: str | None = None      # from FILM_SIM_LOGO mapping
 
 
 def _to_recipe_data(recipe: models.FujifilmRecipe) -> RecipeData:
@@ -404,6 +409,8 @@ def _to_recipe_data(recipe: models.FujifilmRecipe) -> RecipeData:
         clarity=recipe.clarity,
         monochromatic_color_warm_cool=recipe.monochromatic_color_warm_cool,
         monochromatic_color_magenta_green=recipe.monochromatic_color_magenta_green,
+        cover_image_id=getattr(recipe, "cover_image_id", None),
+        film_sim_logo_filename=FILM_SIM_LOGO.get(recipe.film_simulation),
     )
 
 
@@ -419,8 +426,8 @@ def get_filtered_recipes(
     Pass an empty dict to return all recipes.
 
     Results are ordered by:
-    1. Image count descending (most-used recipes first).
-    2. Whether the recipe has a name — named recipes before unnamed.
+    1. Whether the recipe has a name — named recipes before unnamed.
+    2. Image count descending (most-used recipes first).
     3. Primary key ascending as a stable tiebreaker.
     """
     qs = models.FujifilmRecipe.objects.annotate(
@@ -434,8 +441,135 @@ def get_filtered_recipes(
     for field, values in active_filters.items():
         if values:
             qs = qs.filter(**{f"{field}__in": values})
-    qs = qs.order_by("-image_count", "-has_name", "pk")
+    qs = qs.order_by("-has_name", "-image_count", "pk")
     return [_to_recipe_data(r) for r in qs]
+
+
+def get_recipe_sidebar_filter_options(
+    *,
+    active_filters: Mapping[str, Sequence[str]],
+) -> dict[str, dict]:
+    """Return faceted filter options for the recipe explorer sidebar.
+
+    For each field in RECIPE_FILTER_FIELDS, counts the number of recipes matching
+    that field value while applying all OTHER active filters (faceted search).
+    Counts represent recipes, not images.
+    """
+    result = {}
+    for field, label in filter_queries.RECIPE_FILTER_FIELDS:
+        model_field = models.FujifilmRecipe._meta.get_field(field)
+        is_integer = isinstance(model_field, db_models.IntegerField)
+
+        base_qs = models.FujifilmRecipe.objects.all()
+        for other_field, values in active_filters.items():
+            if other_field == field or not values:
+                continue
+            base_qs = base_qs.filter(**{f"{other_field}__in": values})
+        if is_integer:
+            base_qs = base_qs.exclude(**{f"{field}__isnull": True})
+        else:
+            base_qs = base_qs.exclude(**{field: ""})
+
+        available_counts: dict[str, int] = {
+            str(row[field]): row["count"]
+            for row in base_qs.values(field).annotate(count=Count("pk"))
+        }
+        selected_values = active_filters.get(field, [])
+        all_values: set[str] = set(available_counts) | set(selected_values)
+
+        if is_integer:
+            def _sort_key(v: str) -> tuple:
+                try:
+                    return (0 if v in available_counts else 1, int(v))
+                except (ValueError, TypeError):
+                    return (0 if v in available_counts else 1, 0)
+            sorted_values = sorted(all_values, key=_sort_key)
+        else:
+            sorted_values = sorted(
+                all_values,
+                key=lambda v: (0 if v in available_counts else 1, v),
+            )
+
+        result[field] = {
+            "label": label,
+            "options": [
+                {
+                    "value": v,
+                    "count": available_counts.get(v, 0),
+                    "available": v in available_counts,
+                    "selected": v in selected_values,
+                }
+                for v in sorted_values
+            ],
+            "selected": selected_values,
+        }
+    return result
+
+
+@attrs.frozen
+class RecipeGalleryPage:
+    items: tuple[RecipeData, ...]
+    has_next: bool
+    next_page_number: int | None  # None when has_next is False
+    has_previous: bool
+    number: int
+
+
+@attrs.frozen
+class RecipeGalleryData:
+    page_obj: RecipeGalleryPage
+    sidebar_options: dict
+
+
+def get_recipe_gallery_data(
+    *,
+    active_filters: Mapping[str, Sequence[str]],
+    page_number: int | str,
+    page_size: int,
+) -> RecipeGalleryData:
+    """Return all data needed to render the recipe explorer page.
+
+    Filters recipes by *active_filters* (multi-valued field lookups), annotates
+    each with its image count and the ID of its most popular image (for the card
+    background), paginates, and returns domain value objects — no ORM models escape.
+
+    Results are ordered by:
+    1. Whether the recipe has a name — named recipes before unnamed.
+    2. Image count descending (most-used recipes first).
+    3. Primary key ascending as a stable tiebreaker.
+    """
+    cover_subquery = (
+        models.Image.objects
+        .filter(fujifilm_recipe=OuterRef("pk"))
+        .order_by("-rating", "-taken_at", "id")
+        .values("id")[:1]
+    )
+    qs = models.FujifilmRecipe.objects.annotate(
+        image_count=Count("images"),
+        has_name=Case(
+            When(name="", then=Value(0)),
+            default=Value(1),
+            output_field=IntegerField(),
+        ),
+        cover_image_id=Subquery(cover_subquery),
+    )
+    for field, values in active_filters.items():
+        if values:
+            qs = qs.filter(**{f"{field}__in": values})
+    qs = qs.order_by("-has_name", "-image_count", "pk")
+
+    raw_page = django_paginator.Paginator(qs, page_size).get_page(page_number)
+    page = RecipeGalleryPage(
+        items=tuple(_to_recipe_data(r) for r in raw_page.object_list),
+        has_next=raw_page.has_next(),
+        next_page_number=raw_page.next_page_number() if raw_page.has_next() else None,
+        has_previous=raw_page.has_previous(),
+        number=raw_page.number,
+    )
+    return RecipeGalleryData(
+        page_obj=page,
+        sidebar_options=get_recipe_sidebar_filter_options(active_filters=active_filters),
+    )
 
 
 @attrs.frozen
@@ -455,8 +589,8 @@ def get_recipe_list(
     e.g. ``{"film_simulation": "Provia"}``.  Pass an empty dict to list all recipes.
 
     Results are ordered by:
-    1. Image count descending (most-used recipes first).
-    2. Whether the recipe has a name — named recipes before unnamed.
+    1. Whether the recipe has a name — named recipes before unnamed.
+    2. Image count descending (most-used recipes first).
     3. Primary key ascending as a stable tiebreaker.
     """
     qs = (
@@ -470,7 +604,7 @@ def get_recipe_list(
                 output_field=IntegerField(),
             ),
         )
-        .order_by("-image_count", "-has_name", "pk")
+        .order_by("-has_name", "-image_count", "pk")
     )
     page_obj = django_paginator.Paginator(qs, page_size).get_page(page_number)
     return RecipeListPage(page_obj=page_obj)

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+
 import attrs
-from django.db.models import Count, Max, Min
+from django.core import paginator as django_paginator
+from django.db.models import Case, Count, IntegerField, Max, Min, Value, When
 from django.db.models.functions import TruncMonth
 
 from src.data import models
@@ -351,3 +354,123 @@ def get_path_deltas(*, path_ids: list[int]) -> PathDeltaResult:
         path_nodes=tuple(path_nodes),
         missing_ids=missing,
     )
+
+
+@attrs.frozen
+class RecipeData:
+    id: int
+    name: str
+    film_simulation: str
+    dynamic_range: str
+    d_range_priority: str
+    grain_roughness: str
+    grain_size: str
+    color_chrome_effect: str
+    color_chrome_fx_blue: str
+    white_balance: str
+    white_balance_red: int
+    white_balance_blue: int
+    image_count: int
+    highlight: object = None       # Decimal | None
+    shadow: object = None          # Decimal | None
+    color: object = None           # Decimal | None
+    sharpness: object = None       # Decimal | None
+    high_iso_nr: object = None     # Decimal | None
+    clarity: object = None         # Decimal | None
+    monochromatic_color_warm_cool: object = None    # Decimal | None
+    monochromatic_color_magenta_green: object = None  # Decimal | None
+
+
+def _to_recipe_data(recipe: models.FujifilmRecipe) -> RecipeData:
+    return RecipeData(
+        id=recipe.pk,
+        name=recipe.name,
+        film_simulation=recipe.film_simulation,
+        dynamic_range=recipe.dynamic_range,
+        d_range_priority=recipe.d_range_priority,
+        grain_roughness=recipe.grain_roughness,
+        grain_size=recipe.grain_size,
+        color_chrome_effect=recipe.color_chrome_effect,
+        color_chrome_fx_blue=recipe.color_chrome_fx_blue,
+        white_balance=recipe.white_balance,
+        white_balance_red=recipe.white_balance_red,
+        white_balance_blue=recipe.white_balance_blue,
+        image_count=getattr(recipe, "image_count", 0),
+        highlight=recipe.highlight,
+        shadow=recipe.shadow,
+        color=recipe.color,
+        sharpness=recipe.sharpness,
+        high_iso_nr=recipe.high_iso_nr,
+        clarity=recipe.clarity,
+        monochromatic_color_warm_cool=recipe.monochromatic_color_warm_cool,
+        monochromatic_color_magenta_green=recipe.monochromatic_color_magenta_green,
+    )
+
+
+def get_filtered_recipes(
+    *,
+    active_filters: Mapping[str, Sequence[str]],
+) -> list[RecipeData]:
+    """Return all recipes matching the given multi-valued field filters.
+
+    *active_filters* maps recipe field names to lists of allowed values,
+    e.g. ``{"film_simulation": ["Provia", "Classic Chrome"], "grain_roughness": ["Off"]}``.
+    An empty list for a key is ignored (treated as no filter on that field).
+    Pass an empty dict to return all recipes.
+
+    Results are ordered by:
+    1. Image count descending (most-used recipes first).
+    2. Whether the recipe has a name — named recipes before unnamed.
+    3. Primary key ascending as a stable tiebreaker.
+    """
+    qs = models.FujifilmRecipe.objects.annotate(
+        image_count=Count("images"),
+        has_name=Case(
+            When(name="", then=Value(0)),
+            default=Value(1),
+            output_field=IntegerField(),
+        ),
+    )
+    for field, values in active_filters.items():
+        if values:
+            qs = qs.filter(**{f"{field}__in": values})
+    qs = qs.order_by("-image_count", "-has_name", "pk")
+    return [_to_recipe_data(r) for r in qs]
+
+
+@attrs.frozen
+class RecipeListPage:
+    page_obj: object  # Django Page; object_list contains FujifilmRecipe instances
+
+
+def get_recipe_list(
+    *,
+    filters: Mapping[str, object],
+    page_number: int | str,
+    page_size: int,
+) -> RecipeListPage:
+    """Return a paginated list of recipes matching the given field filters.
+
+    *filters* is a mapping of ORM field lookup kwargs (equality by default),
+    e.g. ``{"film_simulation": "Provia"}``.  Pass an empty dict to list all recipes.
+
+    Results are ordered by:
+    1. Image count descending (most-used recipes first).
+    2. Whether the recipe has a name — named recipes before unnamed.
+    3. Primary key ascending as a stable tiebreaker.
+    """
+    qs = (
+        models.FujifilmRecipe.objects
+        .filter(**filters)
+        .annotate(
+            image_count=Count("images"),
+            has_name=Case(
+                When(name="", then=Value(0)),
+                default=Value(1),
+                output_field=IntegerField(),
+            ),
+        )
+        .order_by("-image_count", "-has_name", "pk")
+    )
+    page_obj = django_paginator.Paginator(qs, page_size).get_page(page_number)
+    return RecipeListPage(page_obj=page_obj)

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 import attrs
 from django.core import paginator as django_paginator
 from django.db import models as db_models
-from django.db.models import Case, Count, IntegerField, Max, Min, OuterRef, Subquery, Value, When
+from django.db.models import Case, Count, IntegerField, Max, Min, OuterRef, Q, Subquery, Value, When
 from django.db.models.functions import TruncMonth
 
 from src.data import models
@@ -417,6 +417,7 @@ def _to_recipe_data(recipe: models.FujifilmRecipe) -> RecipeData:
 def get_filtered_recipes(
     *,
     active_filters: Mapping[str, Sequence[str]],
+    name_search: str = "",
 ) -> list[RecipeData]:
     """Return all recipes matching the given multi-valued field filters.
 
@@ -424,6 +425,8 @@ def get_filtered_recipes(
     e.g. ``{"film_simulation": ["Provia", "Classic Chrome"], "grain_roughness": ["Off"]}``.
     An empty list for a key is ignored (treated as no filter on that field).
     Pass an empty dict to return all recipes.
+
+    *name_search* is an optional case-insensitive substring filter on the recipe name.
 
     Results are ordered by:
     1. Whether the recipe has a name — named recipes before unnamed.
@@ -441,6 +444,8 @@ def get_filtered_recipes(
     for field, values in active_filters.items():
         if values:
             qs = qs.filter(**{f"{field}__in": values})
+    if name_search:
+        qs = qs.filter(Q(name__icontains=name_search))
     qs = qs.order_by("-has_name", "-image_count", "pk")
     return [_to_recipe_data(r) for r in qs]
 
@@ -448,12 +453,15 @@ def get_filtered_recipes(
 def get_recipe_sidebar_filter_options(
     *,
     active_filters: Mapping[str, Sequence[str]],
+    name_search: str = "",
 ) -> dict[str, dict]:
     """Return faceted filter options for the recipe explorer sidebar.
 
     For each field in RECIPE_FILTER_FIELDS, counts the number of recipes matching
     that field value while applying all OTHER active filters (faceted search).
     Counts represent recipes, not images.
+
+    *name_search* is applied to all facet counts so they reflect the current search.
     """
     result = {}
     for field, label in filter_queries.RECIPE_FILTER_FIELDS:
@@ -461,6 +469,8 @@ def get_recipe_sidebar_filter_options(
         is_integer = isinstance(model_field, db_models.IntegerField)
 
         base_qs = models.FujifilmRecipe.objects.all()
+        if name_search:
+            base_qs = base_qs.filter(Q(name__icontains=name_search))
         for other_field, values in active_filters.items():
             if other_field == field or not values:
                 continue
@@ -524,6 +534,7 @@ class RecipeGalleryData:
 def get_recipe_gallery_data(
     *,
     active_filters: Mapping[str, Sequence[str]],
+    name_search: str = "",
     page_number: int | str,
     page_size: int,
 ) -> RecipeGalleryData:
@@ -532,6 +543,8 @@ def get_recipe_gallery_data(
     Filters recipes by *active_filters* (multi-valued field lookups), annotates
     each with its image count and the ID of its most popular image (for the card
     background), paginates, and returns domain value objects — no ORM models escape.
+
+    *name_search* is an optional case-insensitive substring filter on the recipe name.
 
     Results are ordered by:
     1. Whether the recipe has a name — named recipes before unnamed.
@@ -556,6 +569,8 @@ def get_recipe_gallery_data(
     for field, values in active_filters.items():
         if values:
             qs = qs.filter(**{f"{field}__in": values})
+    if name_search:
+        qs = qs.filter(Q(name__icontains=name_search))
     qs = qs.order_by("-has_name", "-image_count", "pk")
 
     raw_page = django_paginator.Paginator(qs, page_size).get_page(page_number)
@@ -568,7 +583,7 @@ def get_recipe_gallery_data(
     )
     return RecipeGalleryData(
         page_obj=page,
-        sidebar_options=get_recipe_sidebar_filter_options(active_filters=active_filters),
+        sidebar_options=get_recipe_sidebar_filter_options(active_filters=active_filters, name_search=name_search),
     )
 
 

--- a/src/interfaces/templates/recipes/includes/recipe_results.html
+++ b/src/interfaces/templates/recipes/includes/recipe_results.html
@@ -1,0 +1,22 @@
+{% for recipe in page_obj.items %}
+<article class="recipe-card"
+         style="{% if recipe.cover_image_id %}background-image: url('/images/file/{{ recipe.cover_image_id }}/?width=600');{% endif %}">
+  <div class="recipe-card__overlay">
+    <div class="recipe-card__bottom">
+      {% if recipe.film_sim_logo_filename %}
+        <img class="recipe-card__logo"
+             src="/static/images/{{ recipe.film_sim_logo_filename }}"
+             alt="{{ recipe.film_simulation }}">
+      {% endif %}
+      <div class="recipe-card__info">
+        <span class="recipe-card__name">
+          {% if recipe.name %}{{ recipe.name }}{% else %}{{ recipe.film_simulation }} #{{ recipe.id }}{% endif %}
+        </span>
+        <span class="recipe-card__count">{{ recipe.image_count }} image{{ recipe.image_count|pluralize }}</span>
+      </div>
+    </div>
+  </div>
+</article>
+{% empty %}
+  <p class="no-results">No recipes match the selected filters.</p>
+{% endfor %}

--- a/src/interfaces/templates/recipes/includes/sidebar_filters.html
+++ b/src/interfaces/templates/recipes/includes/sidebar_filters.html
@@ -1,0 +1,21 @@
+<div id="recipe-sidebar-filters"{% if oob %} hx-swap-oob="true"{% endif %}>
+  {% for field, opts in sidebar_options.items %}
+    {% if opts.options %}
+      <div class="filter-group">
+        <label class="filter-label">{{ opts.label }}</label>
+        <div class="filter-checkboxes">
+          {% for option in opts.options %}
+            <label class="filter-option{% if not option.available %} filter-option--unavailable{% endif %}">
+              <input type="checkbox"
+                     name="{{ field }}"
+                     value="{{ option.value }}"
+                     {% if option.selected %}checked{% endif %}>
+              <span class="filter-option-value">{{ option.value }}</span>
+              <span class="filter-option-count">({{ option.count }})</span>
+            </label>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  {% endfor %}
+</div>

--- a/src/interfaces/templates/recipes/partials/htmx_filter_response.html
+++ b/src/interfaces/templates/recipes/partials/htmx_filter_response.html
@@ -1,0 +1,14 @@
+{% include "recipes/includes/recipe_results.html" %}
+<div id="recipe-load-more-sentinel" hx-swap-oob="true">
+  {% if page_obj.has_next %}
+  <div class="infinite-scroll-sentinel"
+       hx-get="{% url 'recipes-explorer-partial-results' %}"
+       hx-include="#recipe-filter-form"
+       hx-vals='{"page": "{{ page_obj.next_page_number }}"}'
+       hx-trigger="intersect root:.recipe-gallery-scroll"
+       hx-target="#recipe-load-more-sentinel"
+       hx-swap="outerHTML">
+  </div>
+  {% endif %}
+</div>
+{% with oob=True %}{% include "recipes/includes/sidebar_filters.html" %}{% endwith %}

--- a/src/interfaces/templates/recipes/partials/htmx_scroll_response.html
+++ b/src/interfaces/templates/recipes/partials/htmx_scroll_response.html
@@ -1,0 +1,15 @@
+<div id="recipe-load-more-sentinel">
+  {% if page_obj.has_next %}
+  <div class="infinite-scroll-sentinel"
+       hx-get="{% url 'recipes-explorer-partial-results' %}"
+       hx-include="#recipe-filter-form"
+       hx-vals='{"page": "{{ page_obj.next_page_number }}"}'
+       hx-trigger="intersect root:.recipe-gallery-scroll"
+       hx-target="#recipe-load-more-sentinel"
+       hx-swap="outerHTML">
+  </div>
+  {% endif %}
+</div>
+<div hx-swap-oob="beforeend:#recipe-gallery-results">
+  {% include "recipes/includes/recipe_results.html" %}
+</div>

--- a/src/interfaces/templates/recipes/recipe_graph.html
+++ b/src/interfaces/templates/recipes/recipe_graph.html
@@ -30,6 +30,7 @@
 
     .sidebar-nav {
       display: flex;
+      flex-direction: column;
       gap: 0.25rem;
       margin-bottom: 1.5rem;
     }
@@ -232,7 +233,7 @@
     <h2>Recipes</h2>
     <nav class="sidebar-nav">
       <a href="{% url 'recipes-explorer' %}" class="sidebar-nav__link">Explorer</a>
-      <a class="sidebar-nav__link sidebar-nav__link--active">Graph</a>
+      <a href="{% url 'recipes-graph' %}" class="sidebar-nav__link sidebar-nav__link--active">Graph</a>
     </nav>
     {% if recipe_name %}
     <p class="sidebar-recipe-name">{{ recipe_name }}</p>

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Recipes</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { display: flex; flex-direction: column; font-family: sans-serif; height: 100vh; overflow: hidden; }
@@ -67,6 +68,87 @@
       border-color: #2db37a;
     }
 
+    .clear-filters-btn {
+      display: block;
+      width: 100%;
+      padding: 0.35rem 0.5rem;
+      margin-bottom: 1.2rem;
+      background: none;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      color: #666;
+      cursor: pointer;
+      text-align: center;
+      text-decoration: none;
+    }
+
+    .clear-filters-btn:hover {
+      background: #f0f0f0;
+      color: #333;
+    }
+
+    .filter-group {
+      margin-bottom: 1.2rem;
+    }
+
+    .filter-label {
+      display: block;
+      font-weight: 600;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #444;
+      margin-bottom: 0.35rem;
+    }
+
+    .filter-checkboxes {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+      max-height: 180px;
+      overflow-y: auto;
+    }
+
+    .filter-option {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      padding: 0.1rem 0.2rem;
+      border-radius: 3px;
+      color: #333;
+      user-select: none;
+    }
+
+    .filter-option:hover { background: #f0f0f0; }
+
+    .filter-option--unavailable {
+      color: #bbb;
+    }
+
+    .filter-option--unavailable input[type="checkbox"] {
+      opacity: 0.4;
+    }
+
+    .filter-option-value {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .filter-option-count {
+      font-size: 0.75rem;
+      color: #999;
+      flex-shrink: 0;
+    }
+
+    .filter-option--unavailable .filter-option-count {
+      color: #ccc;
+    }
+
     .main {
       flex: 1;
       min-width: 0;
@@ -75,17 +157,95 @@
       overflow: hidden;
     }
 
-    .section-header {
+    .gallery-header {
       display: flex;
       align-items: center;
-      gap: 1rem;
-      padding: 0.75rem 1.5rem;
-      background: #fff;
-      border-bottom: 1px solid #e0e0e0;
+      padding: 2rem 2rem 1rem;
       flex-shrink: 0;
     }
 
-    .section-header h1 { font-size: 1rem; font-weight: 600; color: #222; }
+    .gallery-header h1 {
+      font-size: 1.5rem;
+      color: #222;
+    }
+
+    .recipe-gallery-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0 2rem 2rem;
+    }
+
+    #recipe-gallery-results {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+    }
+
+    .infinite-scroll-sentinel {
+      height: 300px;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .recipe-card {
+      position: relative;
+      height: 260px;
+      border-radius: 8px;
+      overflow: hidden;
+      background: #1a1a1a no-repeat center/cover;
+    }
+
+    .recipe-card__overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      padding: 0.75rem;
+      background: linear-gradient(to top, rgba(0,0,0,0.72) 0%, transparent 55%);
+    }
+
+    .recipe-card__bottom {
+      display: flex;
+      align-items: flex-end;
+      gap: 0.5rem;
+    }
+
+    .recipe-card__logo {
+      width: 46.4px;
+      height: 46.4px;
+      flex-shrink: 0;
+      object-fit: contain;
+      filter: drop-shadow(0 1px 2px rgba(0,0,0,0.6));
+    }
+
+    .recipe-card__info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .recipe-card__name {
+      display: block;
+      color: #fff;
+      font-weight: 700;
+      font-size: 1.2rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .recipe-card__count {
+      display: block;
+      color: rgba(255,255,255,0.75);
+      font-size: 0.75rem;
+      margin-top: 0.15rem;
+    }
+
+    .no-results {
+      grid-column: 1 / -1;
+      color: #888;
+      font-style: italic;
+    }
   </style>
 </head>
 <body>
@@ -100,11 +260,36 @@
       <a class="sidebar-nav__link sidebar-nav__link--active">Explorer</a>
       <a href="{% url 'recipes-graph' %}" class="sidebar-nav__link">Graph</a>
     </nav>
+    <a href="{% url 'recipes-explorer' %}" class="clear-filters-btn">Clear all filters</a>
+    <form id="recipe-filter-form"
+          hx-get="{% url 'recipes-explorer' %}"
+          hx-trigger="change"
+          hx-target="#recipe-gallery-results"
+          hx-push-url="true">
+      {% include "recipes/includes/sidebar_filters.html" %}
+    </form>
   </aside>
 
   <main class="main">
-    <div class="section-header">
+    <div class="gallery-header">
       <h1>Explorer</h1>
+    </div>
+    <div class="recipe-gallery-scroll">
+      <div id="recipe-gallery-results" class="recipe-grid">
+        {% include "recipes/includes/recipe_results.html" %}
+      </div>
+      <div id="recipe-load-more-sentinel">
+        {% if page_obj.has_next %}
+        <div class="infinite-scroll-sentinel"
+             hx-get="{% url 'recipes-explorer-partial-results' %}"
+             hx-include="#recipe-filter-form"
+             hx-vals='{"page": "{{ page_obj.next_page_number }}"}'
+             hx-trigger="intersect root:.recipe-gallery-scroll"
+             hx-target="#recipe-load-more-sentinel"
+             hx-swap="outerHTML">
+        </div>
+        {% endif %}
+      </div>
     </div>
   </main>
 

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -68,6 +68,23 @@
       border-color: #2db37a;
     }
 
+    .recipe-name-search {
+      display: block;
+      width: 100%;
+      padding: 0.35rem 0.5rem;
+      margin-bottom: 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      color: #333;
+      background: #fff;
+    }
+
+    .recipe-name-search:focus {
+      outline: none;
+      border-color: #2db37a;
+    }
+
     .clear-filters-btn {
       display: block;
       width: 100%;
@@ -263,9 +280,15 @@
     <a href="{% url 'recipes-explorer' %}" class="clear-filters-btn">Clear all filters</a>
     <form id="recipe-filter-form"
           hx-get="{% url 'recipes-explorer' %}"
-          hx-trigger="change"
+          hx-trigger="change, input delay:300ms from:#recipe-name-search"
           hx-target="#recipe-gallery-results"
           hx-push-url="true">
+      <input id="recipe-name-search"
+             type="search"
+             name="name_search"
+             class="recipe-name-search"
+             placeholder="Search by name…"
+             value="{{ name_search }}">
       {% include "recipes/includes/sidebar_filters.html" %}
     </form>
   </aside>

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -29,20 +29,25 @@
 
     .sidebar-nav {
       display: flex;
+      flex-direction: row;
       gap: 0.25rem;
       margin-bottom: 1.5rem;
     }
 
     .sidebar-nav__link {
-      display: inline-flex;
+      flex: 1;
+      display: flex;
       align-items: center;
-      padding: 0.25rem 0.6rem;
+      justify-content: center;
+      padding: 0.35rem 0.6rem;
       border-radius: 4px;
+      border: 1px solid #ccc;
       font-size: 0.8rem;
       font-weight: 500;
       color: #555;
       text-decoration: none;
       cursor: default;
+      text-align: center;
     }
 
     .sidebar-nav__link[href] {
@@ -50,14 +55,16 @@
     }
 
     .sidebar-nav__link[href]:hover {
-      background: #f0f0f0;
+      background: #e8e8e8;
       color: #222;
+      border-color: #bbb;
     }
 
     .sidebar-nav__link--active {
       background: #f0fdf4;
       color: #2db37a;
       font-weight: 600;
+      border-color: #2db37a;
     }
 
     .main {

--- a/src/interfaces/templates/recipes/recipes_graph.html
+++ b/src/interfaces/templates/recipes/recipes_graph.html
@@ -30,25 +30,30 @@
 
     .sidebar-nav {
       display: flex;
+      flex-direction: row;
       gap: 0.25rem;
       margin-bottom: 1.5rem;
     }
 
     .sidebar-nav__link {
-      display: inline-flex;
+      flex: 1;
+      display: flex;
       align-items: center;
-      padding: 0.25rem 0.6rem;
+      justify-content: center;
+      padding: 0.35rem 0.6rem;
       border-radius: 4px;
+      border: 1px solid #ccc;
       font-size: 0.8rem;
       font-weight: 500;
       color: #555;
       text-decoration: none;
       cursor: default;
+      text-align: center;
     }
 
     .sidebar-nav__link[href] { cursor: pointer; }
-    .sidebar-nav__link[href]:hover { background: #f0f0f0; color: #222; }
-    .sidebar-nav__link--active { background: #f0fdf4; color: #2db37a; font-weight: 600; }
+    .sidebar-nav__link[href]:hover { background: #e8e8e8; color: #222; border-color: #bbb; }
+    .sidebar-nav__link--active { background: #f0fdf4; color: #2db37a; font-weight: 600; border-color: #2db37a; }
 
     .main {
       flex: 1;
@@ -256,7 +261,7 @@
     <h2>Recipes</h2>
     <nav class="sidebar-nav">
       <a href="{% url 'recipes-explorer' %}" class="sidebar-nav__link">Explorer</a>
-      <a class="sidebar-nav__link sidebar-nav__link--active">Graph</a>
+      <a href="{% url 'recipes-graph' %}" class="sidebar-nav__link sidebar-nav__link--active">Graph</a>
     </nav>
   </aside>
 

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -247,8 +247,35 @@ class SetRecipeName(generic.View):
         return shortcuts.render(request, "recipes/_recipe_name_row.html", {"recipe": self.recipe})
 
 
+def _recipe_explorer_filters_from_request(request: http.HttpRequest) -> dict[str, list[str]]:
+    return {
+        field: request.GET.getlist(field)
+        for field, _ in filter_queries.RECIPE_FILTER_FIELDS
+        if request.GET.getlist(field)
+    }
+
+
 def recipes_explorer_view(request: http.HttpRequest) -> http.HttpResponse:
-    return shortcuts.render(request, "recipes/recipes_explorer.html")
+    active_filters = _recipe_explorer_filters_from_request(request)
+    gallery = recipe_queries.get_recipe_gallery_data(
+        active_filters=active_filters,
+        page_number=request.GET.get("page", 1),
+        page_size=settings.RECIPE_EXPLORER_PAGE_SIZE,
+    )
+    ctx = {"page_obj": gallery.page_obj, "sidebar_options": gallery.sidebar_options}
+    if request.headers.get("HX-Request"):
+        return shortcuts.render(request, "recipes/partials/htmx_filter_response.html", ctx)
+    return shortcuts.render(request, "recipes/recipes_explorer.html", ctx)
+
+
+def recipes_explorer_results_view(request: http.HttpRequest) -> http.HttpResponse:
+    active_filters = _recipe_explorer_filters_from_request(request)
+    gallery = recipe_queries.get_recipe_gallery_data(
+        active_filters=active_filters,
+        page_number=request.GET.get("page", 1),
+        page_size=settings.RECIPE_EXPLORER_PAGE_SIZE,
+    )
+    return shortcuts.render(request, "recipes/partials/htmx_scroll_response.html", {"page_obj": gallery.page_obj})
 
 
 _RECIPES_GRAPH_DEFAULT_FILM_SIM = "Provia"

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -257,12 +257,14 @@ def _recipe_explorer_filters_from_request(request: http.HttpRequest) -> dict[str
 
 def recipes_explorer_view(request: http.HttpRequest) -> http.HttpResponse:
     active_filters = _recipe_explorer_filters_from_request(request)
+    name_search = request.GET.get("name_search", "").strip()
     gallery = recipe_queries.get_recipe_gallery_data(
         active_filters=active_filters,
+        name_search=name_search,
         page_number=request.GET.get("page", 1),
         page_size=settings.RECIPE_EXPLORER_PAGE_SIZE,
     )
-    ctx = {"page_obj": gallery.page_obj, "sidebar_options": gallery.sidebar_options}
+    ctx = {"page_obj": gallery.page_obj, "sidebar_options": gallery.sidebar_options, "name_search": name_search}
     if request.headers.get("HX-Request"):
         return shortcuts.render(request, "recipes/partials/htmx_filter_response.html", ctx)
     return shortcuts.render(request, "recipes/recipes_explorer.html", ctx)
@@ -270,8 +272,10 @@ def recipes_explorer_view(request: http.HttpRequest) -> http.HttpResponse:
 
 def recipes_explorer_results_view(request: http.HttpRequest) -> http.HttpResponse:
     active_filters = _recipe_explorer_filters_from_request(request)
+    name_search = request.GET.get("name_search", "").strip()
     gallery = recipe_queries.get_recipe_gallery_data(
         active_filters=active_filters,
+        name_search=name_search,
         page_number=request.GET.get("page", 1),
         page_size=settings.RECIPE_EXPLORER_PAGE_SIZE,
     )

--- a/tests/functional/test_recipe_explorer_gallery.py
+++ b/tests/functional/test_recipe_explorer_gallery.py
@@ -1,0 +1,272 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.test import override_settings
+
+from tests.factories import FujifilmRecipeFactory, ImageFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_explorer(client, **params):
+    return client.get("/recipes/", params)
+
+
+def _get_results(client, **params):
+    return client.get("/recipes/partial/results/", params)
+
+
+def _cards(response):
+    soup = BeautifulSoup(response.content, "html.parser")
+    return soup.find_all(class_="recipe-card")
+
+
+def _card_names(response):
+    soup = BeautifulSoup(response.content, "html.parser")
+    return [el.get_text(strip=True) for el in soup.find_all(class_="recipe-card__name")]
+
+
+# ---------------------------------------------------------------------------
+# Gallery rendering
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipeExplorerGallery:
+    def test_returns_200(self, client):
+        response = _get_explorer(client)
+
+        assert response.status_code == 200
+
+    def test_recipe_cards_visible(self, client):
+        FujifilmRecipeFactory()
+        FujifilmRecipeFactory()
+
+        response = _get_explorer(client)
+
+        assert len(_cards(response)) == 2
+
+    def test_named_recipe_shows_name_on_card(self, client):
+        FujifilmRecipeFactory(name="Street Provia", film_simulation="Provia")
+
+        response = _get_explorer(client)
+
+        assert "Street Provia" in _card_names(response)
+
+    def test_unnamed_recipe_shows_film_simulation_and_id_on_card(self, client):
+        recipe = FujifilmRecipeFactory(name="", film_simulation="Velvia")
+
+        response = _get_explorer(client)
+
+        assert f"Velvia #{recipe.id}" in _card_names(response)
+
+    def test_named_recipes_come_before_unnamed(self, client):
+        unnamed = FujifilmRecipeFactory(name="", film_simulation="Provia")
+        FujifilmRecipeFactory(name="Named One", film_simulation="Velvia")
+
+        response = _get_explorer(client)
+
+        names = _card_names(response)
+        assert names.index("Named One") < names.index(f"Provia #{unnamed.id}")
+
+    def test_named_recipe_with_fewer_images_beats_unnamed_with_more(self, client):
+        named_few = FujifilmRecipeFactory(name="Named Few")
+        unnamed_many = FujifilmRecipeFactory(name="", film_simulation="Velvia")
+        ImageFactory.create_batch(5, fujifilm_recipe=unnamed_many)
+        ImageFactory(fujifilm_recipe=named_few)
+
+        response = _get_explorer(client)
+
+        names = _card_names(response)
+        assert names.index("Named Few") < names.index(f"Velvia #{unnamed_many.id}")
+
+    def test_within_named_recipes_more_images_comes_first(self, client):
+        few = FujifilmRecipeFactory(name="Few")
+        many = FujifilmRecipeFactory(name="Many")
+        ImageFactory.create_batch(5, fujifilm_recipe=many)
+        ImageFactory(fujifilm_recipe=few)
+
+        response = _get_explorer(client)
+
+        names = _card_names(response)
+        assert names.index("Many") < names.index("Few")
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipeExplorerFiltering:
+    def test_film_simulation_filter_returns_only_matching_recipes(self, client):
+        FujifilmRecipeFactory(name="Provia Recipe", film_simulation="Provia")
+        FujifilmRecipeFactory(name="Velvia Recipe", film_simulation="Velvia")
+
+        response = _get_explorer(client, film_simulation="Provia")
+
+        names = _card_names(response)
+        assert "Provia Recipe" in names
+        assert "Velvia Recipe" not in names
+
+    def test_multiple_values_for_same_field(self, client):
+        FujifilmRecipeFactory(name="Provia Recipe", film_simulation="Provia")
+        FujifilmRecipeFactory(name="Velvia Recipe", film_simulation="Velvia")
+        FujifilmRecipeFactory(name="Astia Recipe", film_simulation="Astia")
+
+        response = client.get("/recipes/?film_simulation=Provia&film_simulation=Velvia")
+
+        names = _card_names(response)
+        assert "Provia Recipe" in names
+        assert "Velvia Recipe" in names
+        assert "Astia Recipe" not in names
+
+    def test_no_results_message_when_nothing_matches(self, client):
+        FujifilmRecipeFactory(film_simulation="Provia")
+
+        response = _get_explorer(client, film_simulation="Velvia")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="no-results") is not None
+
+    def test_clear_filters_button_present(self, client):
+        response = _get_explorer(client)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="clear-filters-btn") is not None
+
+    def test_clear_filters_href_points_to_explorer_root(self, client):
+        response = _get_explorer(client, film_simulation="Provia")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        btn = soup.find(class_="clear-filters-btn")
+        assert btn is not None
+        assert btn.get("href") == "/recipes/"
+
+
+# ---------------------------------------------------------------------------
+# Sidebar
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipeExplorerSidebar:
+    def test_sidebar_shows_filter_options(self, client):
+        FujifilmRecipeFactory(film_simulation="Provia")
+
+        response = _get_explorer(client)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        sidebar = soup.find(id="recipe-sidebar-filters")
+        assert sidebar is not None
+        assert sidebar.find("input", {"value": "Provia"}) is not None
+
+    def test_sidebar_counts_recipes_not_images(self, client):
+        # 1 recipe with 5 images, 1 recipe with 1 image — same film_simulation
+        # sidebar count must be 2 (recipes), not 6 (images)
+        recipe_a = FujifilmRecipeFactory(film_simulation="Provia")
+        recipe_b = FujifilmRecipeFactory(film_simulation="Provia")
+        ImageFactory.create_batch(5, fujifilm_recipe=recipe_a)
+        ImageFactory(fujifilm_recipe=recipe_b)
+
+        response = _get_explorer(client)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        provia_label = soup.find("input", {"name": "film_simulation", "value": "Provia"})
+        assert provia_label is not None
+        count_span = provia_label.find_next_sibling(class_="filter-option-count")
+        assert count_span is not None
+        assert count_span.get_text(strip=True) == "(2)"
+
+    def test_selected_option_marked_as_checked(self, client):
+        FujifilmRecipeFactory(film_simulation="Provia")
+
+        response = _get_explorer(client, film_simulation="Provia")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        provia_input = soup.find("input", {"name": "film_simulation", "value": "Provia"})
+        assert provia_input is not None
+        assert provia_input.has_attr("checked")
+
+
+# ---------------------------------------------------------------------------
+# HTMX partial responses
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipeExplorerHtmx:
+    def test_htmx_request_returns_partial_without_doctype(self, client):
+        response = client.get("/recipes/", HTTP_HX_REQUEST="true")
+
+        assert response.status_code == 200
+        assert b"<!DOCTYPE" not in response.content
+
+    def test_htmx_response_contains_oob_sidebar(self, client):
+        FujifilmRecipeFactory(film_simulation="Provia")
+
+        response = client.get("/recipes/", HTTP_HX_REQUEST="true")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        sidebar = soup.find(id="recipe-sidebar-filters")
+        assert sidebar is not None
+        assert sidebar.get("hx-swap-oob") == "true"
+
+
+# ---------------------------------------------------------------------------
+# Pagination / infinite scroll
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipeExplorerPagination:
+    @override_settings(RECIPE_EXPLORER_PAGE_SIZE=2)
+    def test_sentinel_present_when_more_pages(self, client):
+        FujifilmRecipeFactory.create_batch(3)
+
+        response = _get_explorer(client)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="infinite-scroll-sentinel") is not None
+
+    @override_settings(RECIPE_EXPLORER_PAGE_SIZE=2)
+    def test_sentinel_absent_on_last_page(self, client):
+        FujifilmRecipeFactory.create_batch(2)
+
+        response = _get_explorer(client)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="infinite-scroll-sentinel") is None
+
+    @override_settings(RECIPE_EXPLORER_PAGE_SIZE=2)
+    def test_sentinel_points_to_page_2(self, client):
+        FujifilmRecipeFactory.create_batch(3)
+
+        response = _get_explorer(client)
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        sentinel = soup.find(class_="infinite-scroll-sentinel")
+        assert sentinel is not None
+        assert '"page": "2"' in sentinel.get("hx-vals", "")
+
+    @override_settings(RECIPE_EXPLORER_PAGE_SIZE=2)
+    def test_scroll_endpoint_returns_partial(self, client):
+        FujifilmRecipeFactory.create_batch(3)
+
+        response = _get_results(client, page=2)
+
+        assert response.status_code == 200
+        assert b"<!DOCTYPE" not in response.content
+
+    @override_settings(RECIPE_EXPLORER_PAGE_SIZE=2)
+    def test_second_page_has_correct_recipes(self, client):
+        # 3 recipes with 3, 2, 1 images respectively — page 2 should have the last one
+        r1 = FujifilmRecipeFactory(name="Top")
+        r2 = FujifilmRecipeFactory(name="Mid")
+        r3 = FujifilmRecipeFactory(name="Last")
+        ImageFactory.create_batch(3, fujifilm_recipe=r1)
+        ImageFactory.create_batch(2, fujifilm_recipe=r2)
+        ImageFactory(fujifilm_recipe=r3)
+
+        response = _get_results(client, page=2)
+
+        names = _card_names(response)
+        assert "Last" in names
+        assert "Top" not in names
+        assert "Mid" not in names

--- a/tests/functional/test_recipe_explorer_gallery.py
+++ b/tests/functional/test_recipe_explorer_gallery.py
@@ -188,6 +188,66 @@ class TestRecipeExplorerSidebar:
 
 
 # ---------------------------------------------------------------------------
+# Name search
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipeExplorerNameSearch:
+    def test_name_search_returns_matching_recipe(self, client):
+        FujifilmRecipeFactory(name="Street Provia", film_simulation="Provia")
+        FujifilmRecipeFactory(name="Velvia Summer", film_simulation="Velvia")
+
+        response = _get_explorer(client, name_search="Street")
+
+        names = _card_names(response)
+        assert "Street Provia" in names
+        assert "Velvia Summer" not in names
+
+    def test_name_search_is_case_insensitive(self, client):
+        FujifilmRecipeFactory(name="Street Provia")
+
+        response = _get_explorer(client, name_search="street provia")
+
+        assert "Street Provia" in _card_names(response)
+
+    def test_empty_name_search_returns_all_recipes(self, client):
+        FujifilmRecipeFactory(name="Street Provia")
+        FujifilmRecipeFactory(name="Velvia Summer")
+
+        response = _get_explorer(client, name_search="")
+
+        names = _card_names(response)
+        assert "Street Provia" in names
+        assert "Velvia Summer" in names
+
+    def test_name_search_with_no_match_shows_no_results(self, client):
+        FujifilmRecipeFactory(name="Street Provia")
+
+        response = _get_explorer(client, name_search="Nonexistent")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="no-results") is not None
+
+    def test_name_search_combines_with_field_filter(self, client):
+        FujifilmRecipeFactory(name="Street Provia", film_simulation="Provia")
+        FujifilmRecipeFactory(name="Street Velvia", film_simulation="Velvia")
+
+        response = client.get("/recipes/?film_simulation=Provia&name_search=Street")
+
+        names = _card_names(response)
+        assert "Street Provia" in names
+        assert "Street Velvia" not in names
+
+    def test_name_search_input_is_pre_filled_with_current_value(self, client):
+        response = _get_explorer(client, name_search="Street")
+
+        soup = BeautifulSoup(response.content, "html.parser")
+        search_input = soup.find("input", {"name": "name_search"})
+        assert search_input is not None
+        assert search_input.get("value") == "Street"
+
+
+# ---------------------------------------------------------------------------
 # HTMX partial responses
 # ---------------------------------------------------------------------------
 

--- a/tests/functional/test_static_file_view.py
+++ b/tests/functional/test_static_file_view.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.mark.django_db
+class TestStaticFileView:
+    def test_known_logo_returns_200(self, client):
+        response = client.get("/static/images/classic-chrome.png")
+
+        assert response.status_code == 200
+
+    def test_known_logo_content_type_is_png(self, client):
+        response = client.get("/static/images/classic-chrome.png")
+
+        assert response["Content-Type"] == "image/png"
+
+    def test_unknown_file_returns_404(self, client):
+        response = client.get("/static/images/does-not-exist.png")
+
+        assert response.status_code == 404
+
+    def test_all_film_sim_logos_are_served(self, client):
+        from src.domain.recipes.constants import FILM_SIM_LOGO
+
+        for filename in FILM_SIM_LOGO.values():
+            response = client.get(f"/static/images/{filename}")
+            assert response.status_code == 200, f"/static/images/{filename} returned {response.status_code}"

--- a/tests/integration/domain/test_filtered_recipes_query.py
+++ b/tests/integration/domain/test_filtered_recipes_query.py
@@ -103,7 +103,7 @@ class TestGetFilteredRecipesOrdering:
         ids = [r.id for r in result]
         assert ids.index(named.pk) < ids.index(unnamed.pk)
 
-    def test_image_count_beats_name(self):
+    def test_name_beats_image_count(self):
         named_few = FujifilmRecipeFactory(name="Named")
         unnamed_many = FujifilmRecipeFactory(name="")
         ImageFactory(fujifilm_recipe=unnamed_many)
@@ -112,7 +112,7 @@ class TestGetFilteredRecipesOrdering:
         result = get_filtered_recipes(active_filters={})
 
         ids = [r.id for r in result]
-        assert ids.index(unnamed_many.pk) < ids.index(named_few.pk)
+        assert ids.index(named_few.pk) < ids.index(unnamed_many.pk)
 
     def test_lower_pk_is_stable_tiebreaker(self):
         first = FujifilmRecipeFactory(name="")

--- a/tests/integration/domain/test_filtered_recipes_query.py
+++ b/tests/integration/domain/test_filtered_recipes_query.py
@@ -1,0 +1,165 @@
+import pytest
+
+from src.domain.recipes.queries import RecipeData, get_filtered_recipes
+from tests.factories import FujifilmRecipeFactory, ImageFactory
+
+
+@pytest.mark.django_db
+class TestGetFilteredRecipesReturnType:
+    def test_returns_recipe_data_instances(self):
+        FujifilmRecipeFactory()
+
+        result = get_filtered_recipes(active_filters={})
+
+        assert all(isinstance(r, RecipeData) for r in result)
+
+    def test_returns_empty_list_when_no_recipes_exist(self):
+        result = get_filtered_recipes(active_filters={})
+
+        assert result == []
+
+
+@pytest.mark.django_db
+class TestGetFilteredRecipesFiltering:
+    def test_no_filters_returns_all_recipes(self):
+        recipe_a = FujifilmRecipeFactory()
+        recipe_b = FujifilmRecipeFactory()
+
+        result = get_filtered_recipes(active_filters={})
+
+        ids = [r.id for r in result]
+        assert recipe_a.pk in ids
+        assert recipe_b.pk in ids
+
+    def test_filters_by_single_field_value(self):
+        provia = FujifilmRecipeFactory(film_simulation="Provia")
+        FujifilmRecipeFactory(film_simulation="Classic Chrome")
+
+        result = get_filtered_recipes(active_filters={"film_simulation": ["Provia"]})
+
+        assert [r.id for r in result] == [provia.pk]
+
+    def test_filters_by_multiple_values_for_same_field(self):
+        provia = FujifilmRecipeFactory(film_simulation="Provia")
+        classic = FujifilmRecipeFactory(film_simulation="Classic Chrome")
+        FujifilmRecipeFactory(film_simulation="Velvia")
+
+        result = get_filtered_recipes(
+            active_filters={"film_simulation": ["Provia", "Classic Chrome"]}
+        )
+
+        ids = {r.id for r in result}
+        assert ids == {provia.pk, classic.pk}
+
+    def test_filters_by_multiple_fields(self):
+        match = FujifilmRecipeFactory(film_simulation="Provia", grain_roughness="Off")
+        FujifilmRecipeFactory(film_simulation="Provia", grain_roughness="Strong")
+        FujifilmRecipeFactory(film_simulation="Velvia", grain_roughness="Off")
+
+        result = get_filtered_recipes(
+            active_filters={"film_simulation": ["Provia"], "grain_roughness": ["Off"]}
+        )
+
+        assert [r.id for r in result] == [match.pk]
+
+    def test_empty_list_for_a_key_is_ignored(self):
+        recipe = FujifilmRecipeFactory(film_simulation="Provia")
+
+        result = get_filtered_recipes(
+            active_filters={"film_simulation": [], "grain_roughness": ["Off"]}
+        )
+
+        ids = [r.id for r in result]
+        assert recipe.pk in ids
+
+    def test_returns_empty_list_when_no_recipes_match(self):
+        FujifilmRecipeFactory(film_simulation="Provia")
+
+        result = get_filtered_recipes(active_filters={"film_simulation": ["Velvia"]})
+
+        assert result == []
+
+
+@pytest.mark.django_db
+class TestGetFilteredRecipesOrdering:
+    def test_recipe_with_more_images_comes_first(self):
+        few = FujifilmRecipeFactory()
+        many = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=few)
+        ImageFactory(fujifilm_recipe=many)
+        ImageFactory(fujifilm_recipe=many)
+
+        result = get_filtered_recipes(active_filters={})
+
+        ids = [r.id for r in result]
+        assert ids.index(many.pk) < ids.index(few.pk)
+
+    def test_named_recipe_comes_before_unnamed_when_image_count_is_equal(self):
+        unnamed = FujifilmRecipeFactory(name="")
+        named = FujifilmRecipeFactory(name="My Recipe")
+
+        result = get_filtered_recipes(active_filters={})
+
+        ids = [r.id for r in result]
+        assert ids.index(named.pk) < ids.index(unnamed.pk)
+
+    def test_image_count_beats_name(self):
+        named_few = FujifilmRecipeFactory(name="Named")
+        unnamed_many = FujifilmRecipeFactory(name="")
+        ImageFactory(fujifilm_recipe=unnamed_many)
+        ImageFactory(fujifilm_recipe=unnamed_many)
+
+        result = get_filtered_recipes(active_filters={})
+
+        ids = [r.id for r in result]
+        assert ids.index(unnamed_many.pk) < ids.index(named_few.pk)
+
+    def test_lower_pk_is_stable_tiebreaker(self):
+        first = FujifilmRecipeFactory(name="")
+        second = FujifilmRecipeFactory(name="")
+
+        result = get_filtered_recipes(active_filters={})
+
+        ids = [r.id for r in result]
+        assert ids.index(first.pk) < ids.index(second.pk)
+
+
+@pytest.mark.django_db
+class TestGetFilteredRecipesDataFields:
+    def test_recipe_data_exposes_image_count(self):
+        recipe = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=recipe)
+        ImageFactory(fujifilm_recipe=recipe)
+
+        result = get_filtered_recipes(active_filters={})
+
+        recipe_data = next(r for r in result if r.id == recipe.pk)
+        assert recipe_data.image_count == 2
+
+    def test_recipe_data_exposes_all_recipe_fields(self):
+        recipe = FujifilmRecipeFactory(
+            film_simulation="Provia",
+            dynamic_range="DR200",
+            grain_roughness="Strong",
+            white_balance="Daylight",
+            white_balance_red=3,
+            white_balance_blue=-2,
+        )
+
+        result = get_filtered_recipes(active_filters={})
+
+        data = next(r for r in result if r.id == recipe.pk)
+        assert data.film_simulation == "Provia"
+        assert data.dynamic_range == "DR200"
+        assert data.grain_roughness == "Strong"
+        assert data.white_balance == "Daylight"
+        assert data.white_balance_red == 3
+        assert data.white_balance_blue == -2
+
+    def test_recipe_data_image_count_is_zero_when_no_images(self):
+        recipe = FujifilmRecipeFactory()
+
+        result = get_filtered_recipes(active_filters={})
+
+        data = next(r for r in result if r.id == recipe.pk)
+        assert data.image_count == 0

--- a/tests/integration/domain/test_filtered_recipes_query.py
+++ b/tests/integration/domain/test_filtered_recipes_query.py
@@ -125,6 +125,60 @@ class TestGetFilteredRecipesOrdering:
 
 
 @pytest.mark.django_db
+class TestGetFilteredRecipesNameSearch:
+    def test_matches_exact_name(self):
+        recipe = FujifilmRecipeFactory(name="Street Provia")
+        FujifilmRecipeFactory(name="Velvia Summer")
+
+        result = get_filtered_recipes(active_filters={}, name_search="Street Provia")
+
+        assert [r.id for r in result] == [recipe.pk]
+
+    def test_matches_partial_name(self):
+        recipe = FujifilmRecipeFactory(name="Street Provia")
+        FujifilmRecipeFactory(name="Velvia Summer")
+
+        result = get_filtered_recipes(active_filters={}, name_search="Street")
+
+        assert [r.id for r in result] == [recipe.pk]
+
+    def test_is_case_insensitive(self):
+        recipe = FujifilmRecipeFactory(name="Street Provia")
+
+        result = get_filtered_recipes(active_filters={}, name_search="street provia")
+
+        assert [r.id for r in result] == [recipe.pk]
+
+    def test_empty_name_search_returns_all(self):
+        recipe_a = FujifilmRecipeFactory(name="Street Provia")
+        recipe_b = FujifilmRecipeFactory(name="Velvia Summer")
+
+        result = get_filtered_recipes(active_filters={}, name_search="")
+
+        ids = {r.id for r in result}
+        assert ids == {recipe_a.pk, recipe_b.pk}
+
+    def test_no_match_returns_empty_list(self):
+        FujifilmRecipeFactory(name="Street Provia")
+
+        result = get_filtered_recipes(active_filters={}, name_search="Nonexistent")
+
+        assert result == []
+
+    def test_name_search_combines_with_active_filters(self):
+        match = FujifilmRecipeFactory(name="Street Provia", film_simulation="Provia")
+        FujifilmRecipeFactory(name="Street Velvia", film_simulation="Velvia")
+        FujifilmRecipeFactory(name="Other Provia", film_simulation="Provia")
+
+        result = get_filtered_recipes(
+            active_filters={"film_simulation": ["Provia"]},
+            name_search="Street",
+        )
+
+        assert [r.id for r in result] == [match.pk]
+
+
+@pytest.mark.django_db
 class TestGetFilteredRecipesDataFields:
     def test_recipe_data_exposes_image_count(self):
         recipe = FujifilmRecipeFactory()

--- a/tests/integration/domain/test_recipe_list_query.py
+++ b/tests/integration/domain/test_recipe_list_query.py
@@ -74,7 +74,7 @@ class TestGetRecipeListOrdering:
         ids = [r.pk for r in result.page_obj.object_list]
         assert ids.index(named.pk) < ids.index(unnamed.pk)
 
-    def test_image_count_beats_name(self):
+    def test_name_beats_image_count(self):
         named_few = FujifilmRecipeFactory(name="Named")
         unnamed_many = FujifilmRecipeFactory(name="")
         ImageFactory(fujifilm_recipe=unnamed_many)
@@ -83,7 +83,7 @@ class TestGetRecipeListOrdering:
         result = get_recipe_list(filters={}, page_number=1, page_size=50)
 
         ids = [r.pk for r in result.page_obj.object_list]
-        assert ids.index(unnamed_many.pk) < ids.index(named_few.pk)
+        assert ids.index(named_few.pk) < ids.index(unnamed_many.pk)
 
     def test_lower_pk_is_stable_tiebreaker(self):
         first = FujifilmRecipeFactory(name="")

--- a/tests/integration/domain/test_recipe_list_query.py
+++ b/tests/integration/domain/test_recipe_list_query.py
@@ -1,0 +1,130 @@
+import pytest
+
+from src.domain.recipes.queries import get_recipe_list
+from tests.factories import FujifilmRecipeFactory, ImageFactory
+
+
+@pytest.mark.django_db
+class TestGetRecipeListFiltering:
+    def test_returns_all_recipes_when_no_filters(self):
+        recipe_a = FujifilmRecipeFactory()
+        recipe_b = FujifilmRecipeFactory()
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=50)
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert recipe_a.pk in ids
+        assert recipe_b.pk in ids
+
+    def test_filters_by_film_simulation(self):
+        provia = FujifilmRecipeFactory(film_simulation="Provia")
+        FujifilmRecipeFactory(film_simulation="Classic Chrome")
+
+        result = get_recipe_list(filters={"film_simulation": "Provia"}, page_number=1, page_size=50)
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert ids == [provia.pk]
+
+    def test_filters_by_multiple_fields_simultaneously(self):
+        match = FujifilmRecipeFactory(film_simulation="Provia", grain_roughness="Off")
+        FujifilmRecipeFactory(film_simulation="Provia", grain_roughness="Strong")
+        FujifilmRecipeFactory(film_simulation="Classic Chrome", grain_roughness="Off")
+
+        result = get_recipe_list(
+            filters={"film_simulation": "Provia", "grain_roughness": "Off"},
+            page_number=1,
+            page_size=50,
+        )
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert ids == [match.pk]
+
+    def test_returns_empty_page_when_no_matches(self):
+        FujifilmRecipeFactory(film_simulation="Provia")
+
+        result = get_recipe_list(
+            filters={"film_simulation": "Velvia"},
+            page_number=1,
+            page_size=50,
+        )
+
+        assert list(result.page_obj.object_list) == []
+
+
+@pytest.mark.django_db
+class TestGetRecipeListOrdering:
+    def test_recipe_with_more_images_comes_first(self):
+        few = FujifilmRecipeFactory()
+        many = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=few)
+        ImageFactory(fujifilm_recipe=many)
+        ImageFactory(fujifilm_recipe=many)
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=50)
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert ids.index(many.pk) < ids.index(few.pk)
+
+    def test_named_recipe_comes_before_unnamed_when_image_count_is_equal(self):
+        unnamed = FujifilmRecipeFactory(name="")
+        named = FujifilmRecipeFactory(name="My Recipe")
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=50)
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert ids.index(named.pk) < ids.index(unnamed.pk)
+
+    def test_image_count_beats_name(self):
+        named_few = FujifilmRecipeFactory(name="Named")
+        unnamed_many = FujifilmRecipeFactory(name="")
+        ImageFactory(fujifilm_recipe=unnamed_many)
+        ImageFactory(fujifilm_recipe=unnamed_many)
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=50)
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert ids.index(unnamed_many.pk) < ids.index(named_few.pk)
+
+    def test_lower_pk_is_stable_tiebreaker(self):
+        first = FujifilmRecipeFactory(name="")
+        second = FujifilmRecipeFactory(name="")
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=50)
+
+        ids = [r.pk for r in result.page_obj.object_list]
+        assert ids.index(first.pk) < ids.index(second.pk)
+
+
+@pytest.mark.django_db
+class TestGetRecipeListPagination:
+    def test_page_size_limits_results_per_page(self):
+        FujifilmRecipeFactory.create_batch(5)
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=3)
+
+        assert len(result.page_obj.object_list) == 3
+
+    def test_page_number_selects_correct_page(self):
+        recipes = FujifilmRecipeFactory.create_batch(4)
+
+        page1 = get_recipe_list(filters={}, page_number=1, page_size=2)
+        page2 = get_recipe_list(filters={}, page_number=2, page_size=2)
+
+        ids_p1 = {r.pk for r in page1.page_obj.object_list}
+        ids_p2 = {r.pk for r in page2.page_obj.object_list}
+        assert ids_p1.isdisjoint(ids_p2)
+        assert ids_p1 | ids_p2 == {r.pk for r in recipes}
+
+    def test_has_next_when_more_pages_exist(self):
+        FujifilmRecipeFactory.create_batch(3)
+
+        result = get_recipe_list(filters={}, page_number=1, page_size=2)
+
+        assert result.page_obj.has_next()
+
+    def test_last_page_has_no_next(self):
+        FujifilmRecipeFactory.create_batch(3)
+
+        result = get_recipe_list(filters={}, page_number=2, page_size=2)
+
+        assert not result.page_obj.has_next()


### PR DESCRIPTION
## Recipe Explorer

This is an MVP of the recipe explorer. More functionality is planned: creating recipes, importing/exporting, customising the recipe card cover image, pushing recipes to camera, and more.

![2026-04-11_10-49](https://github.com/user-attachments/assets/78dff79c-85f4-4140-a761-a4974566d290)


### Recipe cards

Each recipe is displayed as a card in a 3-column grid showing:
- The recipe's most popular image as a card background (picked by rating, then taken_at, then id via a correlated subquery)
- The film simulation logo (bottom-left)
- The recipe name, or film simulation + id for unnamed recipes
- The image count

Cards are ordered by: named recipes first, then image count descending, then pk as a stable tiebreaker.

### Sidebar filters

A faceted filter sidebar lets users narrow the gallery by any recipe field (film simulation, dynamic range, d-range priority, grain, colour chrome, white balance, etc.). Filter counts reflect the number of matching recipes, not images. Selecting a filter updates results and sidebar counts via HTMX without a full page reload.


### Name search

A text search input in the sidebar filters recipes by name in real time (300ms debounce). It combines with the faceted filters — both apply simultaneously. The search is case-insensitive and matches substrings.

### Infinite scroll

Results are paginated and the next page loads automatically as the user scrolls to the bottom, using an intersection-observer sentinel with HTMX OOB swaps to append cards without replacing existing ones.

### Navigation

The Explorer and Graph links in the recipe sidebar are now displayed as a pair of equal-width buttons in the same row.

### Domain queries

Two new domain queries back the feature:
- `get_recipe_gallery_data` — returns a paginated `RecipeGalleryData` with cover image IDs, film sim logo filenames, and faceted sidebar options; accepts `active_filters` and `name_search`
- `get_filtered_recipes` — returns the full matching set as `list[RecipeData]` for non-paginated use cases
- `get_recipe_list` — paginated equivalent with single-value equality filters
