### PR TITLE
Fix grain_size stored as empty string when Grain Effect is Off

### DIFF
--- a/src/application/usecases/recipes/fix_empty_grain_recipes.py
+++ b/src/application/usecases/recipes/fix_empty_grain_recipes.py
@@ -1,0 +1,70 @@
+import attrs
+
+from src.data import models
+
+
+@attrs.frozen
+class FixResult:
+    updated_in_place: tuple[int, ...]
+    merged: tuple[int, ...]
+
+
+def fix_empty_grain_recipes() -> FixResult:
+    """Fix FujifilmRecipe rows where grain_roughness is 'Off' but grain_size is ''.
+
+    Two cases are handled:
+
+    - **Unique row**: no existing recipe with the same settings but grain_size
+      'Off' — the buggy row is updated in place.
+    - **Duplicate row**: a correct recipe (grain_size 'Off') already exists —
+      all Image FK references are reassigned to the correct row, and the buggy
+      row is deleted.
+
+    Returns a FixResult with the IDs that were updated or merged.
+    """
+    buggy_qs = models.FujifilmRecipe.objects.filter(grain_roughness="Off", grain_size="")
+
+    updated_in_place: list[int] = []
+    merged: list[int] = []
+
+    for buggy in buggy_qs:
+        correct_kwargs = dict(
+            film_simulation=buggy.film_simulation,
+            dynamic_range=buggy.dynamic_range,
+            d_range_priority=buggy.d_range_priority,
+            grain_roughness=buggy.grain_roughness,
+            grain_size="Off",
+            color_chrome_effect=buggy.color_chrome_effect,
+            color_chrome_fx_blue=buggy.color_chrome_fx_blue,
+            white_balance=buggy.white_balance,
+            white_balance_red=buggy.white_balance_red,
+            white_balance_blue=buggy.white_balance_blue,
+            highlight=buggy.highlight,
+            shadow=buggy.shadow,
+            color=buggy.color,
+            sharpness=buggy.sharpness,
+            high_iso_nr=buggy.high_iso_nr,
+            clarity=buggy.clarity,
+            monochromatic_color_warm_cool=buggy.monochromatic_color_warm_cool,
+            monochromatic_color_magenta_green=buggy.monochromatic_color_magenta_green,
+        )
+
+        try:
+            correct = models.FujifilmRecipe.objects.get(**correct_kwargs)
+        except models.FujifilmRecipe.DoesNotExist:
+            buggy.grain_size = "Off"
+            buggy.save(update_fields=["grain_size"])
+            updated_in_place.append(buggy.id)
+        else:
+            if buggy.name and not correct.name:
+                correct.name = buggy.name
+                correct.save(update_fields=["name"])
+            models.Image.objects.filter(fujifilm_recipe=buggy).update(fujifilm_recipe=correct)
+            buggy_id = buggy.id
+            buggy.delete()
+            merged.append(buggy_id)
+
+    return FixResult(
+        updated_in_place=tuple(updated_in_place),
+        merged=tuple(merged),
+    )

--- a/src/domain/images/operations.py
+++ b/src/domain/images/operations.py
@@ -123,7 +123,7 @@ def process_image(*, image_path: str) -> models.Image:
         dynamic_range=recipe_data.dynamic_range or "",
         d_range_priority=recipe_data.d_range_priority,
         grain_roughness=recipe_data.grain_roughness,
-        grain_size=recipe_data.grain_size or "",
+        grain_size=recipe_data.grain_size if recipe_data.grain_size is not None else "Off",
         color_chrome_effect=recipe_data.color_chrome_effect,
         color_chrome_fx_blue=recipe_data.color_chrome_fx_blue,
         white_balance=recipe_data.white_balance,

--- a/src/interfaces/management/commands/fix_empty_grain_recipes.py
+++ b/src/interfaces/management/commands/fix_empty_grain_recipes.py
@@ -1,0 +1,31 @@
+from django.core.management.base import BaseCommand
+
+from src.application.usecases.recipes import fix_empty_grain_recipes as fix_uc
+
+
+class Command(BaseCommand):
+    help = (
+        "Fix FujifilmRecipe rows where grain_roughness is 'Off' but grain_size is '' "
+        "(empty string). Rows are either updated in place or merged into an existing "
+        "correct row, with images reassigned before deletion."
+    )
+
+    def handle(self, *args, **options):
+        result = fix_uc.fix_empty_grain_recipes()
+
+        for recipe_id in result.updated_in_place:
+            self.stdout.write(f"Updated recipe #{recipe_id}: grain_size set to 'Off'.")
+
+        for recipe_id in result.merged:
+            self.stdout.write(
+                f"Merged recipe #{recipe_id}: images reassigned to correct row, buggy row deleted."
+            )
+
+        total = len(result.updated_in_place) + len(result.merged)
+        if total == 0:
+            self.stdout.write("No recipes with empty grain_size found. Nothing to do.")
+        else:
+            self.stdout.write(self.style.SUCCESS(
+                f"Done. {len(result.updated_in_place)} updated in place, "
+                f"{len(result.merged)} merged."
+            ))

--- a/tests/functional/test_fix_empty_grain_recipes.py
+++ b/tests/functional/test_fix_empty_grain_recipes.py
@@ -1,0 +1,101 @@
+import pytest
+from django.core.management import call_command
+
+from src.data.models import FujifilmRecipe, Image
+from tests.factories import FujifilmRecipeFactory, ImageFactory
+
+
+@pytest.mark.django_db
+class TestFixEmptyGrainRecipesCommand:
+    def test_updates_unique_buggy_row_in_place(self):
+        """A buggy row with no matching correct row is updated in place."""
+        buggy = FujifilmRecipeFactory(grain_roughness="Off", grain_size="")
+
+        call_command("fix_empty_grain_recipes")
+
+        buggy.refresh_from_db()
+        assert buggy.grain_size == "Off"
+        assert FujifilmRecipe.objects.count() == 1
+
+    def test_reassigns_images_and_deletes_buggy_row_when_correct_row_exists(self):
+        """When a correct 'Off' row already exists, images are reassigned and the buggy row deleted."""
+        correct = FujifilmRecipeFactory(grain_roughness="Off", grain_size="Off", white_balance_red=1)
+        buggy = FujifilmRecipeFactory(
+            grain_roughness="Off",
+            grain_size="",
+            white_balance_red=correct.white_balance_red,
+            white_balance_blue=correct.white_balance_blue,
+            film_simulation=correct.film_simulation,
+            dynamic_range=correct.dynamic_range,
+            d_range_priority=correct.d_range_priority,
+            color_chrome_effect=correct.color_chrome_effect,
+            color_chrome_fx_blue=correct.color_chrome_fx_blue,
+            white_balance=correct.white_balance,
+        )
+        image = ImageFactory(fujifilm_recipe=buggy)
+        buggy_id = buggy.id
+
+        call_command("fix_empty_grain_recipes")
+
+        image.refresh_from_db()
+        assert image.fujifilm_recipe_id == correct.id
+        assert not FujifilmRecipe.objects.filter(pk=buggy_id).exists()
+        assert FujifilmRecipe.objects.count() == 1
+
+    def test_does_not_touch_rows_with_correct_grain_size(self):
+        """Rows already storing 'Off' are left untouched."""
+        recipe = FujifilmRecipeFactory(grain_roughness="Off", grain_size="Off")
+
+        call_command("fix_empty_grain_recipes")
+
+        recipe.refresh_from_db()
+        assert recipe.grain_size == "Off"
+
+    def test_does_not_touch_non_off_roughness_rows(self):
+        """Rows with non-Off roughness are not affected even if grain_size is empty."""
+        recipe = FujifilmRecipeFactory(grain_roughness="Weak", grain_size="")
+
+        call_command("fix_empty_grain_recipes")
+
+        recipe.refresh_from_db()
+        assert recipe.grain_size == ""
+
+    def test_transfers_name_from_buggy_row_to_correct_row_on_merge(self):
+        """A name on the buggy row is transferred to the unnamed correct row during a merge."""
+        correct = FujifilmRecipeFactory(grain_roughness="Off", grain_size="Off", white_balance_red=2, name="")
+        buggy = FujifilmRecipeFactory(
+            grain_roughness="Off",
+            grain_size="",
+            name="My Recipe",
+            white_balance_red=correct.white_balance_red,
+            white_balance_blue=correct.white_balance_blue,
+            film_simulation=correct.film_simulation,
+            dynamic_range=correct.dynamic_range,
+            d_range_priority=correct.d_range_priority,
+            color_chrome_effect=correct.color_chrome_effect,
+            color_chrome_fx_blue=correct.color_chrome_fx_blue,
+            white_balance=correct.white_balance,
+        )
+
+        call_command("fix_empty_grain_recipes")
+
+        correct.refresh_from_db()
+        assert correct.name == "My Recipe"
+        assert not FujifilmRecipe.objects.filter(pk=buggy.pk).exists()
+
+    def test_outputs_summary(self, capsys):
+        """The command prints a summary of what was fixed."""
+        FujifilmRecipeFactory(grain_roughness="Off", grain_size="")
+
+        call_command("fix_empty_grain_recipes")
+
+        captured = capsys.readouterr()
+        assert "1 updated in place" in captured.out
+        assert "0 merged" in captured.out
+
+    def test_outputs_nothing_to_do_when_no_buggy_rows(self, capsys):
+        """The command reports nothing to do when no buggy rows exist."""
+        call_command("fix_empty_grain_recipes")
+
+        captured = capsys.readouterr()
+        assert "Nothing to do" in captured.out

--- a/tests/integration/domain/test_operations.py
+++ b/tests/integration/domain/test_operations.py
@@ -112,7 +112,7 @@ class TestProcessImagePersistence:
         assert isinstance(recipe, FujifilmRecipe)
         assert recipe.film_simulation == "Classic Negative"
         assert recipe.grain_roughness == "Off"
-        assert recipe.grain_size == ""
+        assert recipe.grain_size == "Off"
         assert recipe.color_chrome_effect == "Off"
         assert recipe.color_chrome_fx_blue == "Strong"
         assert recipe.white_balance == "Auto"


### PR DESCRIPTION
## Problem

When a Fujifilm image with Grain Effect turned off is imported, the `FujifilmRecipe` row was
being created with `grain_size = ""` (empty string) instead of `"Off"`.

**Root cause — two-step bug introduced in a219839** ("Make contextual recipe fields optional"):

1. That commit made `grain_size=None` the domain-layer sentinel for "grain is off, size not
   applicable", and deliberately converted it back to `""` in `operations.py` when persisting
   to the non-nullable DB `CharField` — using `recipe_data.grain_size or ""`.
2. The conversion was wrong: `None` should have become `"Off"`, not `""`. The `GrainEffectSize`
   enum has an explicit `OFF = "Off"` value, and the camera/PTP path maps both Off variants to
   `("Off", "Off")` from constants. Only the EXIF import path got the wrong value.

The integration test in that same commit was updated to assert `""`, locking in the incorrect
behaviour.

## Fix

Changed `operations.py` to `recipe_data.grain_size if recipe_data.grain_size is not None else "Off"`,
and corrected the integration test assertion from `""` to `"Off"`. The `dynamic_range or ""`
conversion on the line above is correct because `""` is the right DB value when dynamic range is
not applicable — there is no `"Off"` sentinel for that field.

## Data repair

Added a `fix_empty_grain_recipes` management command to repair existing rows. It handles two cases:

- **Unique row** — no other recipe with the same settings already exists with `grain_size="Off"`.
  The buggy row is updated in place.
- **Duplicate row** — a correct recipe with `grain_size="Off"` already exists (created before
  `a219839`). All `Image` FK references pointing to the buggy row are reassigned to the correct
  row, then the buggy row is deleted. If the buggy row had a name and the correct one didn't, the
  name is transferred before deletion.

Run once after deploy:

```shell
python manage.py fix_empty_grain_recipes
