### PR TITLE
Grant CREATEDB privilege to PostgreSQL user in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -156,7 +156,7 @@ if [[ "$MODE" == "full" ]]; then
         skip "PostgreSQL user '$DB_USER' already exists"
     else
         info "Creating PostgreSQL user '$DB_USER'..."
-        $PSQL -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS';"
+        $PSQL -c "CREATE USER $DB_USER WITH PASSWORD '$DB_PASS' CREATEDB;"
     fi
 
     info "Checking PostgreSQL database '$DB_NAME'..."


### PR DESCRIPTION
The test suite requires the DB user to be able to create the test database. Without CREATEDB, pytest fails with "permission denied to create database" before any tests run.