### PR TITLE
Add filepath-first matching strategy to find_image_for_path

### DIFF
--- a/src/domain/images/queries.py
+++ b/src/domain/images/queries.py
@@ -235,11 +235,15 @@ def exif_to_recipe(*, exif: image_dataclasses.ImageExifData) -> image_dataclasse
     )
 
 
-def _by_filename_and_date(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None) -> models.Image:
+def _by_filepath(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None, image_path: str) -> models.Image:
+    return models.Image.objects.get(filepath=image_path)
+
+
+def _by_filename_and_date(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None, image_path: str) -> models.Image:
     return models.Image.objects.get(filename=filename, taken_at=date_taken)
 
 
-def _by_date_film_and_wb(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None) -> models.Image:
+def _by_date_film_and_wb(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None, image_path: str) -> models.Image:
     return models.Image.objects.get(
         taken_at=date_taken,
         fujifilm_exif__film_simulation=exif.film_simulation,
@@ -247,19 +251,20 @@ def _by_date_film_and_wb(*, exif: image_dataclasses.ImageExifData, filename: str
     )
 
 
-def _by_date_and_image_count(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None) -> models.Image:
+def _by_date_and_image_count(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None, image_path: str) -> models.Image:
     return models.Image.objects.get(taken_at=date_taken, fujifilm_exif__image_count=exif.image_count)
 
 
-def _by_date_and_film_simulation(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None) -> models.Image:
+def _by_date_and_film_simulation(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None, image_path: str) -> models.Image:
     return models.Image.objects.get(taken_at=date_taken, fujifilm_exif__film_simulation=exif.film_simulation)
 
 
-def _by_date_only(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None) -> models.Image:
+def _by_date_only(*, exif: image_dataclasses.ImageExifData, filename: str, date_taken: datetime | None, image_path: str) -> models.Image:
     return models.Image.objects.get(taken_at=date_taken)
 
 
 _LOOKUP_STRATEGIES = [
+    _by_filepath,
     _by_filename_and_date,
     _by_date_and_image_count,
     _by_date_film_and_wb,
@@ -273,7 +278,7 @@ def find_image_for_path(*, image_path: str) -> models.Image:
 
     Strategies are tried in order; the first one that returns a unique match
     wins. To add a new strategy, append a function with the signature
-    (exif, filename, date_taken) -> Image to _LOOKUP_STRATEGIES.
+    (exif, filename, date_taken, image_path) -> Image to _LOOKUP_STRATEGIES.
 
     Raises ImageNotFound if no strategy finds a match.
     Raises AmbiguousImageMatch if a strategy finds more than one match.
@@ -285,7 +290,7 @@ def find_image_for_path(*, image_path: str) -> models.Image:
     any_ambiguous = False
     for strategy in _LOOKUP_STRATEGIES:
         try:
-            return strategy(exif=exif, filename=filename, date_taken=date_taken)
+            return strategy(exif=exif, filename=filename, date_taken=date_taken, image_path=image_path)
         except django_exceptions.ObjectDoesNotExist:
             continue
         except django_exceptions.MultipleObjectsReturned:

--- a/tests/integration/test_mark_favorites_query.py
+++ b/tests/integration/test_mark_favorites_query.py
@@ -33,10 +33,31 @@ class TestFindImageForPath:
         with pytest.raises(AmbiguousImageMatch):
             find_image_for_path(image_path=FIXTURE_IMAGE)
 
+    def test_by_filepath_resolves_duplicate_filename_and_date(self):
+        # Two records share the same filename and taken_at (e.g. original + Favorites copy).
+        # _by_filepath matches the exact path immediately without reaching the EXIF strategies.
+        exif = FujifilmExifFactory(image_count="18069", film_simulation="Classic Negative", white_balance_fine_tune="Red +3, Blue -5")
+        image_favorites = ImageFactory(filename="XS107114.JPG", filepath=FIXTURE_IMAGE, taken_at=FIXTURE_DATE_UTC, fujifilm_exif=exif)
+        ImageFactory(filename="XS107114.JPG", filepath="/other/folder/XS107114.JPG", taken_at=FIXTURE_DATE_UTC, fujifilm_exif=exif)
+
+        result = find_image_for_path(image_path=FIXTURE_IMAGE)
+
+        assert result.pk == image_favorites.pk
+
+    def test_by_filename_and_date_finds_image_at_different_path(self):
+        # No DB record at the exact fixture path, but one matches filename + taken_at.
+        # _by_filepath misses; _by_filename_and_date succeeds.
+        image = ImageFactory(filename="XS107114.JPG", filepath="/other/folder/XS107114.JPG", taken_at=FIXTURE_DATE_UTC)
+
+        result = find_image_for_path(image_path=FIXTURE_IMAGE)
+
+        assert result.pk == image.pk
+
     def test_continues_to_next_strategy_after_multiple_matches(self):
-        # Strategy 1 (_by_filename_and_date): no match — wrong filename.
-        # Strategy 2 (_by_date_and_image_count): multiple — both records share image_count.
-        # Strategy 3 (_by_date_film_and_wb): 1 match — film_simulation differs.
+        # _by_filepath: no match — fixture path not in DB.
+        # _by_filename_and_date: no match — records have different filenames.
+        # _by_date_and_image_count: multiple — both records share image_count.
+        # _by_date_film_and_wb: 1 match — film_simulation differs.
         exif_a = FujifilmExifFactory(image_count="18069", film_simulation="Classic Negative", white_balance_fine_tune="Red +3, Blue -5")
         exif_b = FujifilmExifFactory(image_count="18069", film_simulation="Classic Chrome", white_balance_fine_tune="Red +0, Blue +0")
         image_a = ImageFactory(filename="BURST001.JPG", filepath="/a/BURST001.JPG", taken_at=FIXTURE_DATE_UTC, fujifilm_exif=exif_a)
@@ -48,8 +69,9 @@ class TestFindImageForPath:
         assert result.pk == image_a.pk
 
     def test_disambiguates_burst_shots_by_image_count(self):
-        # Two burst shots at the same second — only image_count differs.
-        # The fixture image has image_count="18069".
+        # _by_filepath: no match — fixture path not in DB.
+        # _by_filename_and_date: no match — records have different filenames.
+        # _by_date_and_image_count: 1 match — only image_count="18069" matches the fixture.
         exif_a = FujifilmExifFactory(image_count="18069")
         exif_b = FujifilmExifFactory(image_count="18070")
         image_a = ImageFactory(filename="BURST001.JPG", filepath="/a/BURST001.JPG", taken_at=FIXTURE_DATE_UTC, fujifilm_exif=exif_a)


### PR DESCRIPTION
The existing lookup strategies (filename+date, image_count, film+WB) all failed when the same image existed in the DB under two different paths (e.g. original folder and Favorites). Every strategy returned MultipleObjectsReturned, causing rate_images to skip all such images.

Added _by_filepath as the first strategy so that when the exact path is already stored in the DB the match is resolved immediately, without falling through to the EXIF-based strategies. Also added integration tests covering the filepath strategy and the filename+date fallback.