### PR TITLE
Feature import recipe from image

### DIFF
--- a/docs/ADRs/004-recipe-import-file-picker.md
+++ b/docs/ADRs/004-recipe-import-file-picker.md
@@ -1,0 +1,103 @@
+# ADR 004 — Recipe import: browser file upload over native file picker
+
+**Status**: Accepted
+**Date**: 2026-04-12
+
+---
+
+## Context
+
+### The problem
+
+Right now, the only way to create a `FujifilmRecipe` record is by importing an image file that has a recipe encoded in its EXIF data. This is a side effect of `process_image` — the recipe is created incidentally while the image itself is the primary object being imported.
+
+This is limiting because recipes can be shared independently of the images that contain them. A common case: someone shares a JPEG purely as a vehicle for the recipe settings — the image itself is irrelevant. There is currently no way to extract only the recipe from that file through the web UI; the user would have to run a management command.
+
+### Management commands are not enough
+
+Management commands work well for bulk operations and administrative tasks, but they are not a substitute for UI-level interactions. Core user workflows — including importing a recipe — need to be accessible from the browser.
+
+### Why not reuse the image import flow
+
+Importing a recipe from a file is superficially similar to importing an image: both start from a JPEG file. However, the two flows have a critical difference around the filepath:
+
+- **Image import** needs the filepath to persist it on the `Image` record, so the app can locate and render the original file later. This means the file must already live somewhere stable on the filesystem — the user's photo library. The app assumes it does not own or manage those files.
+- **Recipe import** does not store the filepath. Only the EXIF-derived recipe settings matter; the file is discarded after extraction.
+
+This distinction makes a browser file upload (where the server never learns the original path) valid for recipe import but not for image import. Adapting the image import flow to accept browser uploads would require the app to also copy, store, and maintain the uploaded file — turning it into an image catalogue, which is explicitly out of scope. This approach is therefore only suitable for recipe import.
+
+---
+
+## Options considered
+
+### Option A — Server-side native file dialog (tkinter / zenity)
+
+A Django endpoint spawns an OS-level file dialog on the server (e.g. via Python's `tkinter.filedialog` or the `zenity` CLI on Linux). The dialog returns a filesystem path; the view passes it directly to the domain operation with no tempfile needed.
+
+**Why we did not choose this option:**
+
+1. **Architecturally wrong for a web app.** Even though the server and browser are on the same machine, mixing a GUI toolkit into a web server process is a category error. It conflates the server process with the desktop session.
+2. **Ties the server to a display.** `tkinter` requires a running X or Wayland session. The app would break in any headless or SSH context.
+3. **Not composable.** Future deployments (e.g. running the server as a systemd service) would silently fail when no display is available.
+
+### Option B — Plain text input (user types or pastes the path)
+
+A plain `<input type="text">` where the user types a filesystem path. The view receives the string and passes it directly to the domain — zero overhead, no tempfile.
+
+**Why we did not choose this option:**
+
+1. **Poor UX.** Typing a full filesystem path is error-prone and not a web-standard interaction.
+2. **Inconsistent with web conventions.** Users expect a file picker, not a text field, for file selection.
+
+### Option C — Tauri shell wrapping the web UI
+
+[Tauri](https://tauri.app) is a Rust-based desktop shell that hosts a webview. It injects JS APIs (e.g. `window.__TAURI__.dialog.open()`) that call into the Rust layer, which has full OS access and can return a real filesystem path. The path is then POSTed to Django as a plain string — no tempfile needed.
+
+**Why we did not choose this option:**
+
+1. **Disproportionate to the problem.** Introducing a Rust build chain, Tauri packaging, and a desktop distribution model to gain a native file picker is a large architectural shift for a small UX improvement.
+2. **Contradicts the project's web-based identity.** The app is deliberately web-based. Wrapping it in a desktop shell to work around a browser security boundary is the wrong trade-off.
+3. **Browser's `<input type="file">` already solves the user need.** It is the web-standard mechanism for file selection and is universally understood.
+
+### Option D — Browser `<input type="file">` with file contents upload ✓ chosen
+
+The browser's standard file picker. The user selects a file; the browser transfers the file contents (not the path) to the server via a multipart POST. The application layer writes the contents to a tempfile and calls the domain operation with the resulting path. The tempfile is deleted when the operation completes.
+
+---
+
+## Decision
+
+Use `<input type="file">` for file selection. The responsibility is split across layers:
+
+- **Interface layer** (Django view): receives the multipart upload and reads `request.FILES["image"]` into bytes. This is a pure translation — HTTP multipart → `bytes` — with no side effects.
+- **Application layer** (use case): owns the tempfile lifecycle. Writing bytes to `/tmp/` is a side-effectful OS operation with its own failure modes (permissions, disk space). It belongs in the orchestration layer, not the interface or domain.
+- **Domain layer**: unchanged. `get_or_create_recipe_from_filepath(filepath=tmp.name)` is called with a plain path and has no awareness of where the file originated.
+
+```
+interface:    request.FILES["image"].read()  →  bytes        (translation: HTTP → bytes)
+application:  bytes → tempfile → filepath                    (OS coordination, owns cleanup)
+domain:       filepath → exif → FujifilmRecipe               (business logic, unchanged)
+```
+
+---
+
+## Rationale
+
+| Criterion | Native dialog | Text input | Tauri | File upload ✓ |
+|---|---|---|---|---|
+| Web-standard interaction | ✗ | ✗ | ✗ | ✓ |
+| Works headless / as a service | ✗ | ✓ | ✗ | ✓ |
+| No build toolchain beyond Python | ✓ | ✓ | ✗ | ✓ |
+| No tempfile overhead | ✓ | ✓ | ✓ | ✗ |
+| Domain layer unchanged | ✓ | ✓ | ✓ | ✓ |
+
+The tempfile overhead is the only real cost. For an infrequent user action like importing a recipe, it is acceptable.
+
+---
+
+## Consequences
+
+- A file is written to `/tmp/` and deleted per import request. Python's `tempfile.NamedTemporaryFile` handles cleanup automatically, including on exceptions.
+- The browser's security model means the original filesystem path of the file is never available to JS or Django. This is a feature, not a limitation — it keeps the app within web conventions.
+- `get_or_create_recipe_from_filepath` requires no changes.
+- A new use case (e.g. `import_recipe_from_file_content`) is the correct home for the tempfile logic when it is implemented.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,4 +18,5 @@
 - [ADR 001 — Camera Bridge](ADRs/001-camera-bridge.md) — decision to use PyUSB with raw PTP/USB for camera communication
 - [ADR 002 — Recipe Relationship Graph](ADRs/002-recipe-relationship-graph.md) — graph definition, topology decisions, and the two complementary views
 - [ADR 003 — Dual Install Modes](ADRs/003-dual-install-modes.md) — SQLite + sequential vs PostgreSQL + Celery, and why a single-writer queue pattern was ruled out
+- [ADR 004 — Recipe Import File Picker](ADRs/004-recipe-import-file-picker.md) — browser file upload over native dialog or Tauri, and which layer owns the tempfile
 

--- a/src/application/usecases/recipes/import_recipes_from_uploaded_files.py
+++ b/src/application/usecases/recipes/import_recipes_from_uploaded_files.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+
+import attrs
+
+from src.data.models import FujifilmRecipe
+from src.domain.images.queries import NoFilmSimulationError
+from src.domain.recipes import operations
+
+
+@attrs.frozen
+class UploadedFile:
+    """Carries the raw bytes of an uploaded image together with its original filename."""
+
+    name: str
+    content: bytes
+
+
+@attrs.frozen
+class ImportRecipesResult:
+    imported: tuple[FujifilmRecipe, ...]
+    failed: tuple[str, ...]  # original filenames that could not be processed
+
+
+def import_recipes_from_uploaded_files(*, files: list[UploadedFile]) -> ImportRecipesResult:
+    """Extract a FujifilmRecipe from each uploaded file's EXIF data.
+
+    For each file the bytes are written to a temporary file under /tmp/,
+    the recipe is extracted, and the temporary file is deleted immediately
+    afterwards — whether the operation succeeds or fails.
+
+    Files that do not contain Fujifilm recipe EXIF data are recorded as
+    failures; processing continues with the remaining files.
+
+    Returns an ImportRecipesResult describing which files were imported
+    and which failed.
+    """
+    imported: list[FujifilmRecipe] = []
+    failed: list[str] = []
+
+    for file in files:
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".jpg", dir="/tmp/", delete=False) as tmp:
+                tmp.write(file.content)
+                tmp_path = tmp.name
+            recipe = operations.get_or_create_recipe_from_filepath(filepath=tmp_path)
+            imported.append(recipe)
+        except NoFilmSimulationError:
+            failed.append(file.name)
+        finally:
+            if tmp_path is not None:
+                os.unlink(tmp_path)
+
+    return ImportRecipesResult(
+        imported=tuple(imported),
+        failed=tuple(failed),
+    )

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path("images/<int:image_id>/", views.image_detail_view, name="image-detail"),
     path("images/<int:image_id>/set-rating/", views.set_image_rating_view, name="image-set-rating"),
     path("recipes/", views.recipes_explorer_view, name="recipes-explorer"),
+    path("recipes/import/", views.import_recipes_from_uploaded_files_view, name="recipes-import"),
     path("recipes/partial/results/", views.recipes_explorer_results_view, name="recipes-explorer-partial-results"),
     path("recipes/graph/", views.recipes_graph_view, name="recipes-graph"),
     path("recipes/graph/<int:recipe_id>/", views.recipe_graph_view, name="recipe-graph"),

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -227,8 +227,8 @@ class FujifilmRecipe(models.Model):
         clarity: object,
         monochromatic_color_warm_cool: object,
         monochromatic_color_magenta_green: object,
-    ) -> "FujifilmRecipe":
-        obj, _ = cls.objects.get_or_create(  # type: ignore[attr-defined]
+    ) -> "tuple[FujifilmRecipe, bool]":
+        return cls.objects.get_or_create(  # type: ignore[attr-defined]
             film_simulation=film_simulation,
             dynamic_range=dynamic_range,
             d_range_priority=d_range_priority,
@@ -248,7 +248,6 @@ class FujifilmRecipe(models.Model):
             monochromatic_color_warm_cool=monochromatic_color_warm_cool,
             monochromatic_color_magenta_green=monochromatic_color_magenta_green,
         )
-        return obj
 
     # Properties
 

--- a/src/domain/images/events.py
+++ b/src/domain/images/events.py
@@ -4,6 +4,7 @@ logger = structlog.get_logger("events")
 
 
 # Event type constants (reverse domain name notation)
+RECIPE_CREATED = "recipe.created"
 RECIPE_IMAGE_CREATED = "recipe.image.created"
 RECIPE_IMAGE_UPDATED = "recipe.image.updated"
 IMAGE_RATING_SET = "image.rating.set"

--- a/src/domain/images/operations.py
+++ b/src/domain/images/operations.py
@@ -1,30 +1,12 @@
 import attrs
 import os
-from decimal import Decimal
 
 from django import conf
 
 from src.data import models
 from src.domain.images import events, queries
-from src.domain.images import dataclasses as image_dataclasses
-
-
-def _parse_numeric(*, s: str | None) -> Decimal | None:
-    """Convert a signed numeric string like '+4', '-1.5', '0' to Decimal, or None.
-
-    Decimal is used (not float or int) so that half-step values like -1.5 and
-    +0.5 are stored exactly in the DecimalField without rounding.
-    """
-    if s is None or s == "N/A":
-        return None
-    return Decimal(s)
-
-
-@attrs.frozen
-class NoFilmSimulationError(Exception):
-    """Raised when an image has no film simulation in its EXIF data."""
-
-    image_path: str
+from src.domain.images.queries import NoFilmSimulationError  # noqa: F401 — re-exported
+from src.domain.recipes import operations as recipe_operations
 
 
 @attrs.frozen
@@ -114,30 +96,7 @@ def process_image(*, image_path: str) -> models.Image:
 
     fujifilm_exif = models.FujifilmExif.get_or_create(**recipe_fields)
 
-    try:
-        recipe_data = queries.exif_to_recipe(exif=metadata)
-    except KeyError:
-        raise NoFilmSimulationError(image_path)
-    fujifilm_recipe = models.FujifilmRecipe.get_or_create(
-        film_simulation=recipe_data.film_simulation,
-        dynamic_range=recipe_data.dynamic_range or "",
-        d_range_priority=recipe_data.d_range_priority,
-        grain_roughness=recipe_data.grain_roughness,
-        grain_size=recipe_data.grain_size if recipe_data.grain_size is not None else "Off",
-        color_chrome_effect=recipe_data.color_chrome_effect,
-        color_chrome_fx_blue=recipe_data.color_chrome_fx_blue,
-        white_balance=recipe_data.white_balance,
-        white_balance_red=recipe_data.white_balance_red,
-        white_balance_blue=recipe_data.white_balance_blue,
-        highlight=_parse_numeric(s=recipe_data.highlight),
-        shadow=_parse_numeric(s=recipe_data.shadow),
-        color=_parse_numeric(s=recipe_data.color),
-        sharpness=_parse_numeric(s=recipe_data.sharpness),
-        high_iso_nr=_parse_numeric(s=recipe_data.high_iso_nr),
-        clarity=_parse_numeric(s=recipe_data.clarity),
-        monochromatic_color_warm_cool=_parse_numeric(s=recipe_data.monochromatic_color_warm_cool),
-        monochromatic_color_magenta_green=_parse_numeric(s=recipe_data.monochromatic_color_magenta_green),
-    )
+    fujifilm_recipe = recipe_operations.get_or_create_recipe_from_metadata(metadata=metadata)
 
     image, created = models.Image.update_or_create(
         filepath=image_path,

--- a/src/domain/images/queries.py
+++ b/src/domain/images/queries.py
@@ -20,6 +20,13 @@ class AmbiguousImageMatch(Exception):
     """Raised when multiple DB records match the given image file."""
 
 
+@attrs.frozen
+class NoFilmSimulationError(Exception):
+    """Raised when an image has no film simulation in its EXIF data."""
+
+    image_path: str = ""
+
+
 EXIFTOOL_FIELD_MAP = {
     # Standard fields (non-FujiFilm group)
     "Make": "camera_make",

--- a/src/domain/recipes/operations.py
+++ b/src/domain/recipes/operations.py
@@ -1,10 +1,72 @@
 from __future__ import annotations
 
 import attrs
+from decimal import Decimal
 
 from src.data import models
 from src.domain.images import dataclasses as image_dataclasses
 from src.domain.images import events
+from src.domain.images import queries as image_queries
+
+
+def _parse_numeric(*, s: str | None) -> Decimal | None:
+    """Convert a signed numeric string like '+4', '-1.5', '0' to Decimal, or None.
+
+    Decimal is used (not float or int) so that half-step values like -1.5 and
+    +0.5 are stored exactly in the DecimalField without rounding.
+    """
+    if s is None or s == "N/A":
+        return None
+    return Decimal(s)
+
+
+def get_or_create_recipe_from_metadata(*, metadata: image_dataclasses.ImageExifData) -> models.FujifilmRecipe:
+    """Create or retrieve a FujifilmRecipe for the given parsed EXIF data.
+
+    :raises NoFilmSimulationError: If the EXIF data contains no known film simulation.
+    """
+    try:
+        recipe_data = image_queries.exif_to_recipe(exif=metadata)
+    except KeyError:
+        raise image_queries.NoFilmSimulationError()
+    recipe, created = models.FujifilmRecipe.get_or_create(
+        film_simulation=recipe_data.film_simulation,
+        dynamic_range=recipe_data.dynamic_range or "",
+        d_range_priority=recipe_data.d_range_priority,
+        grain_roughness=recipe_data.grain_roughness,
+        grain_size=recipe_data.grain_size if recipe_data.grain_size is not None else "Off",
+        color_chrome_effect=recipe_data.color_chrome_effect,
+        color_chrome_fx_blue=recipe_data.color_chrome_fx_blue,
+        white_balance=recipe_data.white_balance,
+        white_balance_red=recipe_data.white_balance_red,
+        white_balance_blue=recipe_data.white_balance_blue,
+        highlight=_parse_numeric(s=recipe_data.highlight),
+        shadow=_parse_numeric(s=recipe_data.shadow),
+        color=_parse_numeric(s=recipe_data.color),
+        sharpness=_parse_numeric(s=recipe_data.sharpness),
+        high_iso_nr=_parse_numeric(s=recipe_data.high_iso_nr),
+        clarity=_parse_numeric(s=recipe_data.clarity),
+        monochromatic_color_warm_cool=_parse_numeric(s=recipe_data.monochromatic_color_warm_cool),
+        monochromatic_color_magenta_green=_parse_numeric(s=recipe_data.monochromatic_color_magenta_green),
+    )
+    if created:
+        events.publish_event(
+            event_type=events.RECIPE_CREATED,
+            recipe_id=recipe.pk,
+            film_simulation=recipe.film_simulation,
+        )
+    return recipe
+
+
+def get_or_create_recipe_from_filepath(*, filepath: str) -> models.FujifilmRecipe:
+    """Read EXIF from *filepath* and return the matching FujifilmRecipe, creating it if needed.
+
+    :raises NoFilmSimulationError: If the file is not a Fujifilm image or has no film simulation.
+    """
+    metadata = image_queries.read_image_exif(image_path=filepath)
+    if metadata.camera_make.upper() != "FUJIFILM":
+        raise image_queries.NoFilmSimulationError(filepath)
+    return get_or_create_recipe_from_metadata(metadata=metadata)
 
 
 @attrs.frozen

--- a/src/interfaces/templates/recipes/partials/_import_result.html
+++ b/src/interfaces/templates/recipes/partials/_import_result.html
@@ -1,0 +1,29 @@
+{% if error %}
+<div class="import-result import-result--error">
+  <p class="import-result__message">{{ error }}</p>
+</div>
+
+{% elif imported is not None %}
+<div class="import-result import-result--done">
+  {% if imported %}
+  <p class="import-result__message import-result__message--success">
+    {{ imported|length }} recipe{{ imported|length|pluralize }} imported successfully.
+  </p>
+  {% endif %}
+
+  {% if failed %}
+  <p class="import-result__message import-result__message--warning">
+    {{ failed|length }} file{{ failed|length|pluralize }} could not be processed:
+  </p>
+  <ul class="import-result__failed-list">
+    {% for name in failed %}
+    <li>{{ name }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% if not imported and not failed %}
+  <p class="import-result__message">No files were processed.</p>
+  {% endif %}
+</div>
+{% endif %}

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -263,6 +263,172 @@
       color: #888;
       font-style: italic;
     }
+
+    /* ── Create Recipes button + dropdown ───────────────────────────── */
+    .create-recipes-wrap {
+      position: relative;
+      margin-left: auto;
+    }
+
+    .create-recipes-btn {
+      padding: 0.4rem 0.85rem;
+      background: #2db37a;
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .create-recipes-btn:hover { background: #27a06d; }
+
+    .create-recipes-dropdown {
+      position: absolute;
+      top: calc(100% + 6px);
+      right: 0;
+      min-width: 210px;
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+      z-index: 100;
+      overflow: hidden;
+    }
+
+    .create-recipes-dropdown[hidden] { display: none; }
+
+    .create-recipes-option {
+      display: block;
+      width: 100%;
+      padding: 0.65rem 1rem;
+      background: none;
+      border: none;
+      text-align: left;
+      font-size: 0.875rem;
+      color: #333;
+      cursor: pointer;
+    }
+
+    .create-recipes-option:hover { background: #f5f5f5; }
+
+    /* ── Import modal overlay ───────────────────────────────────────── */
+    .import-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.45);
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .import-overlay[hidden] { display: none; }
+
+    .import-modal {
+      background: #fff;
+      border-radius: 10px;
+      padding: 2rem;
+      width: 480px;
+      max-width: calc(100vw - 2rem);
+      max-height: calc(100vh - 4rem);
+      overflow-y: auto;
+      position: relative;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    }
+
+    .import-modal__close {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      background: none;
+      border: none;
+      font-size: 1.4rem;
+      color: #888;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0.2rem 0.4rem;
+    }
+
+    .import-modal__close:hover { color: #333; }
+
+    .import-modal h2 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #222;
+      margin-bottom: 0.5rem;
+    }
+
+    .import-modal__desc {
+      font-size: 0.875rem;
+      color: #666;
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+
+    .upload-from-computer-btn {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      background: #f3f4f6;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #333;
+      cursor: pointer;
+    }
+
+    .upload-from-computer-btn:hover { background: #e8e8e8; }
+
+    #import-file-input { display: none; }
+
+    .selected-files-list {
+      margin: 1rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .selected-files-list li {
+      font-size: 0.825rem;
+      color: #444;
+      padding: 0.2rem 0;
+      border-bottom: 1px solid #f0f0f0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .import-submit-btn {
+      display: block;
+      width: 100%;
+      margin-top: 1.25rem;
+      padding: 0.6rem 1rem;
+      background: #2db37a;
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .import-submit-btn:hover { background: #27a06d; }
+    .import-submit-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+    /* ── Import result messages ─────────────────────────────────────── */
+    .import-result { margin-top: 1.25rem; }
+
+    .import-result__message { font-size: 0.875rem; margin-bottom: 0.35rem; }
+    .import-result__message--success { color: #2db37a; font-weight: 600; }
+    .import-result__message--warning { color: #b36b2d; font-weight: 600; }
+    .import-result--error .import-result__message { color: #c0392b; }
+
+    .import-result__failed-list {
+      margin: 0.25rem 0 0 1rem;
+      font-size: 0.8rem;
+      color: #666;
+    }
   </style>
 </head>
 <body>
@@ -296,6 +462,49 @@
   <main class="main">
     <div class="gallery-header">
       <h1>Explorer</h1>
+
+      <div class="create-recipes-wrap">
+        <button class="create-recipes-btn" id="create-recipes-btn">+ Create Recipes</button>
+        <div class="create-recipes-dropdown" id="create-recipes-dropdown" hidden>
+          <button class="create-recipes-option" id="open-import-modal-btn">Import recipes from images</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Import modal -->
+    <div class="import-overlay" id="import-overlay" hidden>
+      <div class="import-modal" role="dialog" aria-modal="true" aria-labelledby="import-modal-title">
+        <button class="import-modal__close" id="close-import-modal-btn" aria-label="Close">&#x2715;</button>
+        <h2 id="import-modal-title">Import Recipes from Images</h2>
+        <p class="import-modal__desc">
+          Select one or more Fujifilm JPEG files. The recipe settings encoded in
+          their EXIF data will be extracted and saved — the image files themselves
+          are not stored.
+        </p>
+
+        <form id="import-form"
+              hx-post="{% url 'recipes-import' %}"
+              hx-encoding="multipart/form-data"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-target="#import-result"
+              hx-swap="innerHTML"
+              hx-disabled-elt="#import-submit-btn">
+
+          <label class="upload-from-computer-btn" for="import-file-input">
+            Upload from computer
+          </label>
+          <input type="file" id="import-file-input" name="images"
+                 multiple accept=".jpg,.jpeg">
+
+          <ul class="selected-files-list" id="selected-files-list" hidden></ul>
+
+          <button type="submit" class="import-submit-btn" id="import-submit-btn" hidden>
+            Import Recipes from Images
+          </button>
+        </form>
+
+        <div id="import-result"></div>
+      </div>
     </div>
     <div class="recipe-gallery-scroll">
       <div id="recipe-gallery-results" class="recipe-grid">
@@ -318,5 +527,70 @@
 
 </div><!-- .content-area -->
 
+<script>
+  (function () {
+    const createBtn      = document.getElementById('create-recipes-btn');
+    const dropdown       = document.getElementById('create-recipes-dropdown');
+    const openModalBtn   = document.getElementById('open-import-modal-btn');
+    const overlay        = document.getElementById('import-overlay');
+    const closeModalBtn  = document.getElementById('close-import-modal-btn');
+    const fileInput      = document.getElementById('import-file-input');
+    const fileList       = document.getElementById('selected-files-list');
+    const submitBtn      = document.getElementById('import-submit-btn');
+
+    // Toggle dropdown
+    createBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      dropdown.hidden = !dropdown.hidden;
+    });
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function () {
+      dropdown.hidden = true;
+    });
+
+    // Open import modal
+    openModalBtn.addEventListener('click', function () {
+      dropdown.hidden = true;
+      overlay.hidden = false;
+      document.getElementById('import-result').innerHTML = '';
+      fileList.innerHTML = '';
+      fileList.hidden = true;
+      submitBtn.hidden = true;
+      fileInput.value = '';
+    });
+
+    function closeModal() {
+      overlay.hidden = true;
+    }
+
+    closeModalBtn.addEventListener('click', closeModal);
+
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) closeModal();
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !overlay.hidden) closeModal();
+    });
+
+    // Show selected files
+    fileInput.addEventListener('change', function () {
+      fileList.innerHTML = '';
+      if (fileInput.files.length === 0) {
+        fileList.hidden = true;
+        submitBtn.hidden = true;
+        return;
+      }
+      Array.from(fileInput.files).forEach(function (file) {
+        const li = document.createElement('li');
+        li.textContent = file.name;
+        fileList.appendChild(li);
+      });
+      fileList.hidden = false;
+      submitBtn.hidden = false;
+    });
+  })();
+</script>
 </body>
 </html>

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -13,6 +13,7 @@ from django.views.decorators import http as http_decorators
 from src.application.usecases.camera import get_camera_slots as get_camera_slots_uc
 from src.application.usecases.camera import push_recipe as push_recipe_uc
 from src.application.usecases.recipes import build_graph as build_graph_uc
+from src.application.usecases.recipes import import_recipes_from_uploaded_files as import_recipes_uc
 from src.data import models
 from src.domain.camera import ptp_device
 from src.domain.images import filter_queries
@@ -430,6 +431,38 @@ def recipe_compare_image_view(request: http.HttpRequest, recipe_id: int, image_i
         "prev_id": page.prev_id,
         "next_id": page.next_id,
     })
+
+
+@http_decorators.require_POST
+def import_recipes_from_uploaded_files_view(request: http.HttpRequest) -> http.HttpResponse:
+    uploaded = request.FILES.getlist("images")
+    if not uploaded:
+        return shortcuts.render(
+            request,
+            "recipes/partials/_import_result.html",
+            {"error": "No files were uploaded."},
+        )
+
+    files = [
+        import_recipes_uc.UploadedFile(name=f.name, content=f.read())
+        for f in uploaded
+    ]
+
+    try:
+        result = import_recipes_uc.import_recipes_from_uploaded_files(files=files)
+    except Exception:
+        structlog.get_logger().exception("Unexpected error in import_recipes_from_uploaded_files_view")
+        return shortcuts.render(
+            request,
+            "recipes/partials/_import_result.html",
+            {"error": "An unexpected error occurred. Please try again."},
+        )
+
+    return shortcuts.render(
+        request,
+        "recipes/partials/_import_result.html",
+        {"imported": result.imported, "failed": result.failed},
+    )
 
 
 def recipe_path_deltas_view(request: http.HttpRequest) -> http.HttpResponse:

--- a/tests/functional/test_import_recipes_view.py
+++ b/tests/functional/test_import_recipes_view.py
@@ -1,0 +1,146 @@
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from src.data.models import FujifilmRecipe
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "images"
+
+
+def _fixture_upload(filename: str):
+    """Return a file-like object from a fixture image, suitable for client.post FILES."""
+    path = FIXTURES_DIR / filename
+    return BytesIO(path.read_bytes())
+
+
+def _post(client, *filenames):
+    files = [_fixture_upload(f) for f in filenames]
+    data = {"images": files} if len(files) > 1 else {"images": files[0]}
+    return client.post("/recipes/import/", data, format="multipart")
+
+
+# ---------------------------------------------------------------------------
+# Explorer page — Create Recipes button presence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestRecipesExplorerCreateButton:
+    def test_create_recipes_button_is_present(self, client):
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        btn = soup.find("button", id="create-recipes-btn")
+        assert btn is not None
+
+    def test_import_recipes_option_is_present(self, client):
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        btn = soup.find("button", id="open-import-modal-btn")
+        assert btn is not None
+
+    def test_import_modal_is_in_page(self, client):
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(id="import-overlay") is not None
+
+    def test_import_form_posts_to_correct_url(self, client):
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        form = soup.find("form", id="import-form")
+        assert form is not None
+        assert form.get("hx-post") == "/recipes/import/"
+
+
+# ---------------------------------------------------------------------------
+# Import view — method guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestImportRecipesViewMethodGuard:
+    def test_get_returns_405(self, client):
+        response = client.get("/recipes/import/")
+        assert response.status_code == 405
+
+
+# ---------------------------------------------------------------------------
+# Import view — success cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestImportRecipesViewSuccess:
+    def test_returns_200(self, client):
+        response = _post(client, "XS107114.JPG")
+        assert response.status_code == 200
+
+    def test_creates_recipe_in_db(self, client):
+        assert FujifilmRecipe.objects.count() == 0
+        _post(client, "XS107114.JPG")
+        assert FujifilmRecipe.objects.count() == 1
+
+    def test_response_shows_import_count(self, client):
+        response = _post(client, "XS107114.JPG")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "1 recipe" in soup.get_text().lower()
+
+    def test_response_has_no_error(self, client):
+        response = _post(client, "XS107114.JPG")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="import-result--error") is None
+
+    def test_imports_multiple_files(self, client):
+        response = _post(client, "XS107114.JPG", "XS107209.jpg")
+        assert response.status_code == 200
+        assert FujifilmRecipe.objects.count() >= 1
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "2 recipe" in soup.get_text().lower()
+
+    def test_deduplicates_same_recipe(self, client):
+        _post(client, "XS107114.JPG")
+        _post(client, "XS107114.JPG")
+        assert FujifilmRecipe.objects.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Import view — failure cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestImportRecipesViewFailure:
+    def test_no_files_returns_error_message(self, client):
+        response = client.post("/recipes/import/", {})
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="import-result--error") is not None
+
+    def test_non_fujifilm_file_shows_failure(self, client):
+        data = {"images": BytesIO(b"\xff\xd8\xff\xd9")}
+        # Give it a name so the view can identify it
+        data["images"].name = "not_fujifilm.jpg"
+        response = client.post("/recipes/import/", data, format="multipart")
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "not_fujifilm.jpg" in soup.get_text()
+
+    def test_partial_failure_reports_both_success_and_failure(self, client):
+        bad = BytesIO(b"\xff\xd8\xff\xd9")
+        bad.name = "bad.jpg"
+        good = _fixture_upload("XS107114.JPG")
+        good.name = "XS107114.JPG"
+        response = client.post("/recipes/import/", {"images": [bad, good]}, format="multipart")
+        assert response.status_code == 200
+        text = BeautifulSoup(response.content, "html.parser").get_text()
+        assert "1 recipe" in text.lower()
+        assert "bad.jpg" in text
+
+    def test_unexpected_exception_shows_error_message(self, client):
+        with patch(
+            "src.application.usecases.recipes.import_recipes_from_uploaded_files.import_recipes_from_uploaded_files",
+            side_effect=RuntimeError("boom"),
+        ):
+            response = _post(client, "XS107114.JPG")
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="import-result--error") is not None
+        assert "unexpected" in soup.get_text().lower()

--- a/tests/integration/application/recipes/test_import_recipes_from_uploaded_files.py
+++ b/tests/integration/application/recipes/test_import_recipes_from_uploaded_files.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+
+import pytest
+
+from src.application.usecases.recipes.import_recipes_from_uploaded_files import (
+    ImportRecipesResult,
+    UploadedFile,
+    import_recipes_from_uploaded_files,
+)
+from src.data.models import FujifilmRecipe
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent.parent.parent / "fixtures" / "images"
+
+
+def uploaded_file_from_fixture(filename: str) -> UploadedFile:
+    """Build an UploadedFile from a real fixture image, mimicking what the interface
+    layer produces when it calls request.FILES["image"].read()."""
+    path = FIXTURES_DIR / filename
+    return UploadedFile(name=filename, content=path.read_bytes())
+
+
+@pytest.mark.django_db
+class TestImportRecipesFromUploadedFiles:
+    def test_imports_recipe_from_single_file(self):
+        files = [uploaded_file_from_fixture("XS107114.JPG")]
+
+        result = import_recipes_from_uploaded_files(files=files)
+
+        assert len(result.imported) == 1
+        assert isinstance(result.imported[0], FujifilmRecipe)
+        assert result.imported[0].film_simulation == "Classic Negative"
+        assert result.failed == ()
+
+    def test_imports_recipes_from_multiple_files(self):
+        files = [
+            uploaded_file_from_fixture("XS107114.JPG"),
+            uploaded_file_from_fixture("XS107209.jpg"),
+        ]
+
+        result = import_recipes_from_uploaded_files(files=files)
+
+        assert len(result.imported) == 2
+        assert result.failed == ()
+
+    def test_deduplicates_identical_recipes(self):
+        files = [
+            uploaded_file_from_fixture("XS107114.JPG"),
+            uploaded_file_from_fixture("XS107114.JPG"),
+        ]
+
+        result = import_recipes_from_uploaded_files(files=files)
+
+        assert len(result.imported) == 2
+        assert result.imported[0].pk == result.imported[1].pk
+        assert FujifilmRecipe.objects.count() == 1
+
+    def test_records_failure_for_non_fujifilm_file(self):
+        non_fujifilm = UploadedFile(name="canon.jpg", content=b"\xff\xd8\xff\xd9")
+        files = [non_fujifilm]
+
+        result = import_recipes_from_uploaded_files(files=files)
+
+        assert result.imported == ()
+        assert result.failed == ("canon.jpg",)
+
+    def test_continues_after_failure_and_processes_remaining_files(self):
+        non_fujifilm = UploadedFile(name="bad.jpg", content=b"\xff\xd8\xff\xd9")
+        files = [
+            non_fujifilm,
+            uploaded_file_from_fixture("XS107114.JPG"),
+        ]
+
+        result = import_recipes_from_uploaded_files(files=files)
+
+        assert len(result.imported) == 1
+        assert result.failed == ("bad.jpg",)
+
+    def test_temp_file_is_deleted_after_success(self, tmp_path, monkeypatch):
+        created_paths: list[str] = []
+
+        original_unlink = __import__("os").unlink
+
+        def tracking_unlink(path: str) -> None:
+            created_paths.append(path)
+            original_unlink(path)
+
+        monkeypatch.setattr("src.application.usecases.recipes.import_recipes_from_uploaded_files.os.unlink", tracking_unlink)
+
+        files = [uploaded_file_from_fixture("XS107114.JPG")]
+        import_recipes_from_uploaded_files(files=files)
+
+        assert len(created_paths) == 1
+        assert not Path(created_paths[0]).exists()
+
+    def test_temp_file_is_deleted_after_failure(self, monkeypatch):
+        created_paths: list[str] = []
+
+        original_unlink = __import__("os").unlink
+
+        def tracking_unlink(path: str) -> None:
+            created_paths.append(path)
+            original_unlink(path)
+
+        monkeypatch.setattr("src.application.usecases.recipes.import_recipes_from_uploaded_files.os.unlink", tracking_unlink)
+
+        files = [UploadedFile(name="bad.jpg", content=b"\xff\xd8\xff\xd9")]
+        import_recipes_from_uploaded_files(files=files)
+
+        assert len(created_paths) == 1
+        assert not Path(created_paths[0]).exists()
+
+    def test_empty_file_list_returns_empty_result(self):
+        result = import_recipes_from_uploaded_files(files=[])
+
+        assert result == ImportRecipesResult(imported=(), failed=())

--- a/tests/integration/domain/test_get_or_create_recipe_from_filepath.py
+++ b/tests/integration/domain/test_get_or_create_recipe_from_filepath.py
@@ -1,0 +1,82 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.data.models import FujifilmRecipe
+from src.domain.images import events
+from src.domain.images.queries import NoFilmSimulationError
+from src.domain.recipes.operations import get_or_create_recipe_from_filepath
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent.parent / "fixtures" / "images"
+FIXTURE_IMAGE = str(FIXTURES_DIR / "XS107114.JPG")
+
+NON_FUJIFILM_EXIFTOOL_OUTPUT = "[IFD0]          Make                            : Canon\n"
+
+NO_FILM_MODE_EXIFTOOL_OUTPUT = """\
+[IFD0]          Make                            : FUJIFILM
+[IFD0]          Camera Model Name               : X-S10
+[ExifIFD]       ISO                             : 640
+[Composite]     Date/Time Original              : 2025:12:31 12:23:57+11:00
+"""
+
+
+@pytest.mark.django_db
+class TestGetOrCreateRecipeFromFilepath:
+    def test_creates_recipe_from_fixture_image(self):
+        recipe = get_or_create_recipe_from_filepath(filepath=FIXTURE_IMAGE)
+
+        assert isinstance(recipe, FujifilmRecipe)
+        assert recipe.pk is not None
+        assert recipe.film_simulation == "Classic Negative"
+
+    def test_publishes_recipe_created_event(self, captured_logs):
+        recipe = get_or_create_recipe_from_filepath(filepath=FIXTURE_IMAGE)
+
+        created_events = [e for e in captured_logs if e.get("event_type") == events.RECIPE_CREATED]
+        assert len(created_events) == 1
+        assert created_events[0]["recipe_id"] == recipe.pk
+        assert created_events[0]["film_simulation"] == recipe.film_simulation
+
+    def test_does_not_publish_event_when_recipe_already_exists(self, captured_logs):
+        get_or_create_recipe_from_filepath(filepath=FIXTURE_IMAGE)
+        captured_logs.clear()
+        get_or_create_recipe_from_filepath(filepath=FIXTURE_IMAGE)
+
+        created_events = [e for e in captured_logs if e.get("event_type") == events.RECIPE_CREATED]
+        assert created_events == []
+
+    def test_returns_existing_recipe_when_called_twice(self):
+        first = get_or_create_recipe_from_filepath(filepath=FIXTURE_IMAGE)
+        second = get_or_create_recipe_from_filepath(filepath=FIXTURE_IMAGE)
+
+        assert first.pk == second.pk
+
+    def test_raises_for_non_fujifilm_image(self, tmp_path):
+        image_path = str(tmp_path / "canon.jpg")
+        (tmp_path / "canon.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+
+        with patch("src.domain.images.queries.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["exiftool", image_path],
+                returncode=0,
+                stdout=NON_FUJIFILM_EXIFTOOL_OUTPUT,
+                stderr="",
+            )
+            with pytest.raises(NoFilmSimulationError):
+                get_or_create_recipe_from_filepath(filepath=image_path)
+
+    def test_raises_for_missing_film_simulation(self, tmp_path):
+        image_path = str(tmp_path / "no_film_mode.jpg")
+        (tmp_path / "no_film_mode.jpg").write_bytes(b"\xff\xd8\xff\xd9")
+
+        with patch("src.domain.images.queries.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["exiftool", image_path],
+                returncode=0,
+                stdout=NO_FILM_MODE_EXIFTOOL_OUTPUT,
+                stderr="",
+            )
+            with pytest.raises(NoFilmSimulationError):
+                get_or_create_recipe_from_filepath(filepath=image_path)

--- a/tests/unit/domain/test_get_or_create_recipe_from_metadata.py
+++ b/tests/unit/domain/test_get_or_create_recipe_from_metadata.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.domain.images import events
+from src.domain.images.dataclasses import ImageExifData
+from src.domain.recipes.operations import get_or_create_recipe_from_metadata
+
+# ImageExifData with valid values for all fields consumed by exif_to_recipe.
+METADATA = ImageExifData(
+    film_simulation="Classic Negative",
+    color="+4 (highest)",
+    d_range_priority="Fixed",
+    d_range_priority_auto="Strong",
+    white_balance="Auto",
+    white_balance_fine_tune="Red +3, Blue -5",
+    color_temperature="",
+    grain_effect_roughness="Off",
+    grain_effect_size="Off",
+    color_chrome_effect="Off",
+    color_chrome_fx_blue="Strong",
+    sharpness="-1 (medium soft)",
+    noise_reduction="-4 (weakest)",
+    clarity="0",
+    dynamic_range_setting="Manual",
+    development_dynamic_range="400",
+    highlight_tone="0 (normal)",
+    shadow_tone="+1 (medium hard)",
+    bw_adjustment="0",
+    bw_magenta_green="0",
+)
+
+
+class TestGetOrCreateRecipeFromMetadataEventPublishing:
+    def test_publishes_event_when_recipe_is_created(self, captured_logs):
+        recipe = MagicMock()
+        recipe.pk = 99
+        recipe.film_simulation = "Classic Negative"
+
+        with patch("src.data.models.FujifilmRecipe.get_or_create", return_value=(recipe, True)):
+            get_or_create_recipe_from_metadata(metadata=METADATA)
+
+        created_events = [e for e in captured_logs if e.get("event_type") == events.RECIPE_CREATED]
+        assert len(created_events) == 1
+        assert created_events[0]["recipe_id"] == 99
+        assert created_events[0]["film_simulation"] == "Classic Negative"
+
+    def test_does_not_publish_event_when_recipe_already_exists(self, captured_logs):
+        recipe = MagicMock()
+
+        with patch("src.data.models.FujifilmRecipe.get_or_create", return_value=(recipe, False)):
+            get_or_create_recipe_from_metadata(metadata=METADATA)
+
+        created_events = [e for e in captured_logs if e.get("event_type") == events.RECIPE_CREATED]
+        assert created_events == []


### PR DESCRIPTION
## Recipe import via browser file upload

Closes the gap described in [ADR 004](docs/ADRs/004-recipe-import-file-picker.md): until now the only way to create a `FujifilmRecipe` record was as a side-effect of importing an image. This PR adds a dedicated browser-based flow that extracts recipe settings from any Fujifilm JPEG — without storing the image itself.

<img width="3615" height="1626" alt="image" src="https://github.com/user-attachments/assets/f32c445e-7f80-4453-82e2-b9e54026fbe6" />


---

## What was built

### Domain — `get_or_create_recipe_from_filepath`
A new domain operation that reads the EXIF data from a file path and returns (or creates) the matching `FujifilmRecipe`. The existing `process_image` operation is unchanged.

### Application — `import_recipes_from_uploaded_files` usecase
Owns the tempfile lifecycle as prescribed by ADR 004:
- Accepts a list of `UploadedFile(name, content: bytes)` — an application-layer dataclass that keeps Django's `InMemoryUploadedFile` out of the domain.
- Writes each file's bytes to a temp file under `/tmp/`, calls the domain operation, then deletes the temp file in a `finally` block (cleanup always runs, even on failure).
- Catches `NoFilmSimulationError` per file, records the filename in a `failed` tuple, and continues processing the rest.
- Returns `ImportRecipesResult(imported, failed)`.

### Interface — view, URL, templates
- **POST `/recipes/import/`** — reads `request.FILES.getlist("images")`, delegates to the usecase, and returns an HTMX partial. Handles missing files, domain failures, and unexpected exceptions without surfacing a 500.
- **`_import_result.html`** — HTMX response partial showing the number of recipes imported, any filenames that failed, or an error banner.
- **Explorer UI** — a **"+ Create Recipes"** button in the recipes explorer header opens a floating dropdown. "Import recipes from images" opens a modal overlay with a brief explanation, a file picker ("Upload from computer"), a live list of the selected files, and an "Import Recipes from Images" submit button that fires the HTMX POST. The modal closes on ✕, backdrop click, or Esc.
