### PR TITLE
Add recipe detail view with HTMX modal

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path("recipes/partial/results/", views.recipes_explorer_results_view, name="recipes-explorer-partial-results"),
     path("recipes/graph/", views.recipes_graph_view, name="recipes-graph"),
     path("recipes/graph/<int:recipe_id>/", views.recipe_graph_view, name="recipe-graph"),
+    path("recipes/<int:recipe_id>/", views.recipe_detail_view, name="recipe-detail"),
     path("recipes/<int:recipe_id>/images/", views.recipe_images_view, name="recipe-images"),
     path("recipes/<int:recipe_id>/images/<int:image_id>/", views.recipe_compare_image_view, name="recipe-compare-image"),
     path("recipes/path-deltas/", views.recipe_path_deltas_view, name="recipe-path-deltas"),

--- a/src/domain/recipes/constants.py
+++ b/src/domain/recipes/constants.py
@@ -1,3 +1,16 @@
+# Film simulations that support the monochromatic color shift controls (Warm/Cool, Magenta/Green).
+MONOCHROMATIC_FILM_SIMULATIONS: frozenset[str] = frozenset({
+    "Monochrome STD",
+    "Monochrome Yellow",
+    "Monochrome Red",
+    "Monochrome Green",
+    "Sepia",
+    "Acros STD",
+    "Acros Yellow",
+    "Acros Red",
+    "Acros Green",
+})
+
 # Maps film_simulation field value → logo filename under src/interfaces/static/images/.
 # Keys must exactly match the string values stored in FujifilmRecipe.film_simulation,
 # which are defined by FILM_SIMULATION_TO_PTP in src/data/camera/constants.py.

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -10,7 +10,7 @@ from django.db.models.functions import TruncMonth
 
 from src.data import models
 from src.domain.images import filter_queries
-from src.domain.recipes.constants import FILM_SIM_LOGO
+from src.domain.recipes.constants import FILM_SIM_LOGO, MONOCHROMATIC_FILM_SIMULATIONS
 from src.domain.images import dataclasses as image_dataclasses
 
 
@@ -411,6 +411,35 @@ def _to_recipe_data(recipe: models.FujifilmRecipe) -> RecipeData:
         monochromatic_color_magenta_green=recipe.monochromatic_color_magenta_green,
         cover_image_id=getattr(recipe, "cover_image_id", None),
         film_sim_logo_filename=FILM_SIM_LOGO.get(recipe.film_simulation),
+    )
+
+
+@attrs.frozen
+class RecipeDetailContext:
+    recipe: RecipeData
+    is_monochromatic: bool
+
+
+def get_recipe_detail(*, recipe_id: int) -> RecipeDetailContext:
+    """Return the recipe with the given primary key as a RecipeDetailContext.
+
+    :raises models.FujifilmRecipe.DoesNotExist: If no recipe with *recipe_id* exists.
+    """
+    cover_subquery = (
+        models.Image.objects.filter(fujifilm_recipe=OuterRef("pk"))
+        .order_by("-rating", "-taken_at", "id")
+        .values("id")[:1]
+    )
+    recipe = (
+        models.FujifilmRecipe.objects.annotate(
+            image_count=Count("images"),
+            cover_image_id=Subquery(cover_subquery),
+        ).get(pk=recipe_id)
+    )
+    recipe_data = _to_recipe_data(recipe)
+    return RecipeDetailContext(
+        recipe=recipe_data,
+        is_monochromatic=recipe_data.film_simulation in MONOCHROMATIC_FILM_SIMULATIONS,
     )
 
 

--- a/src/interfaces/templates/recipes/_recipe_name_prompt.html
+++ b/src/interfaces/templates/recipes/_recipe_name_prompt.html
@@ -1,27 +1,46 @@
 <form id="recipe-name-prompt-{{ recipe.id }}"
-      class="detail-row recipe-name-prompt"
+      class="recipe-name-prompt"
       hx-post="{% url 'set-recipe-name' recipe_id=recipe.id %}"
       hx-swap="outerHTML"
       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
 
+  {# Title text — hidden while editing #}
+  <span class="recipe-title-display"{% if show_form %} style="display:none"{% endif %}>
+    {% if recipe.name %}{{ recipe.name }}{% else %}{{ recipe.film_simulation }} #{{ recipe.id }}{% endif %}
+  </span>
+
+  {# Input — replaces the title while editing #}
+  <input type="text" name="name" class="recipe-title-input" maxlength="25"
+         placeholder="{% if recipe.name %}{{ recipe.name }}{% else %}{{ recipe.film_simulation }} #{{ recipe.id }}{% endif %}"
+         value="{{ submitted_name|default:recipe.name }}"
+         onkeydown="if(event.key==='Escape'){event.stopPropagation();var p=this.closest('form');p.querySelector('.recipe-name-form-state').style.display='none';p.querySelector('.recipe-title-input').style.display='none';p.querySelector('.recipe-title-display').style.display='';p.querySelector('.recipe-name-btn-state').style.display='flex';}"
+         {% if show_form %} autofocus{% else %} style="display:none"{% endif %}>
+
+  {# "Edit recipe name" button — hidden while editing #}
   <div class="recipe-name-btn-state"{% if show_form %} style="display:none"{% endif %}>
     <button type="button" class="name-recipe-btn"
-            onclick="var p=this.closest('form');p.querySelector('.recipe-name-btn-state').style.display='none';p.querySelector('.recipe-name-form-state').style.display='';p.querySelector('.recipe-name-input').focus()">
-      Name this recipe
+            onclick="var p=this.closest('form');
+                     p.querySelector('.recipe-title-display').style.display='none';
+                     p.querySelector('.recipe-title-input').style.display='';
+                     p.querySelector('.recipe-name-btn-state').style.display='none';
+                     p.querySelector('.recipe-name-form-state').style.display='flex';
+                     p.querySelector('.recipe-title-input').focus();">
+      Edit recipe name
     </button>
   </div>
 
+  {# OK + Cancel — shown while editing #}
   <div class="recipe-name-form-state"{% if not show_form %} style="display:none"{% endif %}>
     {% if error %}<span class="recipe-name-error">{{ error }}</span>{% endif %}
-    <div class="recipe-name-input-row">
-      <input type="text" name="name" class="recipe-name-input" maxlength="25"
-             placeholder="Recipe name (max 25 chars)"
-             value="{{ submitted_name|default:'' }}"{% if show_form %} autofocus{% endif %}>
-      <button type="submit" class="recipe-name-ok-btn">OK</button>
-      <button type="button" class="recipe-name-cancel-btn"
-              onclick="var p=this.closest('form');p.querySelector('.recipe-name-form-state').style.display='none';p.querySelector('.recipe-name-btn-state').style.display=''">
-        Cancel
-      </button>
-    </div>
+    <button type="submit" class="recipe-name-ok-btn">OK</button>
+    <button type="button" class="recipe-name-cancel-btn"
+            onclick="var p=this.closest('form');
+                     p.querySelector('.recipe-name-form-state').style.display='none';
+                     p.querySelector('.recipe-title-input').style.display='none';
+                     p.querySelector('.recipe-title-display').style.display='';
+                     p.querySelector('.recipe-name-btn-state').style.display='flex';">
+      Cancel
+    </button>
   </div>
+
 </form>

--- a/src/interfaces/templates/recipes/_recipe_name_row.html
+++ b/src/interfaces/templates/recipes/_recipe_name_row.html
@@ -1,10 +1,1 @@
-<div class="detail-row">
-  <span class="detail-label">Name</span>
-  <div class="detail-name-row">
-    <span class="detail-value">{{ recipe.name }}</span>
-    <button class="send-to-camera-btn"
-            hx-get="{% url 'select-push-slot' recipe_id=recipe.id %}"
-            hx-target="#slot-overlay"
-            hx-swap="innerHTML">Send to camera</button>
-  </div>
-</div>
+{% include "recipes/_recipe_name_prompt.html" with recipe=recipe %}

--- a/src/interfaces/templates/recipes/includes/recipe_results.html
+++ b/src/interfaces/templates/recipes/includes/recipe_results.html
@@ -1,6 +1,9 @@
 {% for recipe in page_obj.items %}
 <article class="recipe-card"
-         style="{% if recipe.cover_image_id %}background-image: url('/images/file/{{ recipe.cover_image_id }}/?width=600');{% endif %}">
+         style="{% if recipe.cover_image_id %}background-image: url('/images/file/{{ recipe.cover_image_id }}/?width=600');{% endif %} cursor: pointer;"
+         hx-get="{% url 'recipe-detail' recipe.id %}"
+         hx-target="#recipe-detail-overlay"
+         hx-push-url="{% url 'recipe-detail' recipe.id %}">
   <div class="recipe-card__overlay">
     <div class="recipe-card__bottom">
       {% if recipe.film_sim_logo_filename %}

--- a/src/interfaces/templates/recipes/partials/recipe_detail.html
+++ b/src/interfaces/templates/recipes/partials/recipe_detail.html
@@ -1,0 +1,585 @@
+{% load image_filters %}
+<style>
+  .detail-overlay {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    font-family: sans-serif;
+    background: #1a1a1a;
+  }
+
+  .detail-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.75rem 1.5rem;
+    background: #000;
+    flex-shrink: 0;
+    border-bottom: 1px solid #2a2a2a;
+  }
+
+  .header-logo {
+    height: 1.5rem;
+    width: auto;
+    opacity: 0.85;
+    flex-shrink: 0;
+    margin-right: 0.75rem;
+  }
+
+  .detail-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.12);
+    color: #fff;
+    font-size: 1.25rem;
+    text-decoration: none;
+    transition: background 0.15s;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .detail-close:hover { background: rgba(255,255,255,0.25); }
+
+  /* Name prompt in header — title and input share the same slot */
+  .recipe-name-prompt {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    min-width: 0;
+    padding: 0;
+    margin: 0;
+  }
+
+  .recipe-title-display {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #ddd;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  .recipe-title-input {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #ddd;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #555;
+    outline: none;
+    width: 22ch;
+    flex-shrink: 0;
+    padding: 0 0 0.1rem 0;
+  }
+
+  .recipe-title-input:focus { border-bottom-color: #2db37a; }
+
+  .recipe-name-btn-state {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    min-width: 0;
+  }
+
+  .recipe-name-form-state {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .detail-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    justify-content: center;
+  }
+
+  /* Left: recipe settings */
+  .detail-settings-col {
+    flex: 0 1 520px;
+    overflow-y: auto;
+    padding: 2rem 1.5rem;
+    color: #ddd;
+  }
+
+  /* Right: actions */
+  .detail-actions-col {
+    flex: 0 1 340px;
+    overflow-y: auto;
+    padding: 2rem 1.5rem;
+    color: #ddd;
+    border-left: 1px solid #2a2a2a;
+  }
+
+  .detail-section-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #555;
+    margin-bottom: 1rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid #2a2a2a;
+  }
+
+  /* Single-field row */
+  .detail-field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.9rem;
+  }
+
+  .detail-field:last-child { margin-bottom: 0; }
+
+  /* Two-column pair */
+  .detail-pair {
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 0.9rem;
+  }
+
+  .detail-pair:last-child { margin-bottom: 0; }
+
+  .detail-pair .detail-field {
+    flex: 1;
+    margin-bottom: 0;
+  }
+
+  .detail-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #555;
+    margin-bottom: 0.2rem;
+  }
+
+  .field-icon {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+    opacity: 0.8;
+  }
+
+  .detail-value {
+    font-size: 0.95rem;
+    color: #ddd;
+    padding-left: calc(13px + 6px); /* align with label text, past the icon */
+  }
+
+  /* Actions */
+  .action-group {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+
+  .action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 1.1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    border-radius: 6px;
+    cursor: pointer;
+    border: none;
+    transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+  }
+
+  .action-btn--primary {
+    background: #2db37a;
+    color: #fff;
+  }
+
+  .action-btn--primary:hover { background: #26a06c; }
+
+  .action-btn--secondary {
+    background: transparent;
+    color: #aaa;
+    border: 1px solid #444;
+    text-decoration: none;
+  }
+
+  .action-btn--secondary:hover { border-color: #aaa; color: #ddd; }
+
+  .action-btn--disabled {
+    background: transparent;
+    color: #444;
+    border: 1px solid #333;
+    cursor: not-allowed;
+  }
+
+  .action-hint {
+    font-size: 0.75rem;
+    color: #444;
+  }
+
+  /* Edit recipe name button + form */
+  .name-recipe-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    background: transparent;
+    color: #666;
+    border: 1px solid #3a3a3a;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+    white-space: nowrap;
+    flex-shrink: 0;
+    vertical-align: middle;
+    line-height: 1;
+  }
+
+  .name-recipe-btn:hover {
+    border-color: #777;
+    color: #ccc;
+  }
+
+  .recipe-name-ok-btn {
+    padding: 0.4rem 0.7rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #fff;
+    background: #2db37a;
+    border: 1px solid #2db37a;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .recipe-name-cancel-btn {
+    padding: 0.4rem 0.7rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #888;
+    background: transparent;
+    border: 1px solid #555;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .recipe-name-error {
+    display: block;
+    font-size: 0.75rem;
+    color: #e05c5c;
+    margin-bottom: 0.2rem;
+  }
+
+  .detail-image-count {
+    font-size: 0.8rem;
+    color: #444;
+    margin-top: 1.5rem;
+  }
+</style>
+
+<div class="detail-overlay">
+  <header class="detail-header">
+    {% if recipe.film_sim_logo_filename %}
+      <img class="header-logo" src="/static/images/{{ recipe.film_sim_logo_filename }}" alt="{{ recipe.film_simulation }}">
+    {% endif %}
+    {% include "recipes/_recipe_name_prompt.html" with recipe=recipe %}
+    <a href="{% url 'recipes-explorer' %}" class="detail-close" title="Close"
+       onclick="event.preventDefault(); (window._recipeDetailClose || function(){ history.back(); })();">&#x2715;</a>
+  </header>
+
+  <div class="detail-body">
+
+    <!-- Settings -->
+    <div class="detail-settings-col">
+      <h2 class="detail-section-title">Recipe settings</h2>
+
+      {# Film Simulation — film strip #}
+      <div class="detail-field">
+        <span class="detail-label">
+          <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+            <rect x="1" y="2.5" width="12" height="9" rx="0.8"/>
+            <rect x="1.2" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+            <rect x="1.2" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+            <rect x="10.6" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+            <rect x="10.6" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+            <line x1="4.8" y1="2.5" x2="4.8" y2="11.5" stroke-width="0.7" opacity="0.45"/>
+            <line x1="9.2" y1="2.5" x2="9.2" y2="11.5" stroke-width="0.7" opacity="0.45"/>
+          </svg>
+          Film Simulation
+        </span>
+        <span class="detail-value">{{ recipe.film_simulation }}</span>
+      </div>
+
+      {% if is_monochromatic %}
+        {# BW tone shifts — bidirectional horizontal / vertical arrows #}
+        <div class="detail-pair">
+          <div class="detail-field">
+            <span class="detail-label">
+              <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                <line x1="1" y1="7" x2="13" y2="7"/>
+                <polyline points="4,4.5 1,7 4,9.5"/>
+                <polyline points="10,4.5 13,7 10,9.5"/>
+              </svg>
+              BW Warm / Cool
+            </span>
+            <span class="detail-value">{{ recipe.monochromatic_color_warm_cool|signed }}</span>
+          </div>
+          <div class="detail-field">
+            <span class="detail-label">
+              <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                <line x1="7" y1="1" x2="7" y2="13"/>
+                <polyline points="4.5,4 7,1 9.5,4"/>
+                <polyline points="4.5,10 7,13 9.5,10"/>
+              </svg>
+              BW Magenta / Green
+            </span>
+            <span class="detail-value">{{ recipe.monochromatic_color_magenta_green|signed }}</span>
+          </div>
+        </div>
+      {% endif %}
+
+      {# Grain — scattered dots for roughness, varying sizes for grain size #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+              <circle cx="3" cy="3.5" r="1.1"/>
+              <circle cx="8.5" cy="2.5" r="1.1"/>
+              <circle cx="12" cy="5.5" r="1.1"/>
+              <circle cx="5.5" cy="7.5" r="1.1"/>
+              <circle cx="11" cy="9.5" r="1.1"/>
+              <circle cx="2.5" cy="11" r="1.1"/>
+              <circle cx="7.5" cy="11.5" r="1.1"/>
+            </svg>
+            Grain Roughness
+          </span>
+          <span class="detail-value">{{ recipe.grain_roughness }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+              <circle cx="4" cy="9" r="3.5"/>
+              <circle cx="10.5" cy="5" r="1.8"/>
+            </svg>
+            Grain Size
+          </span>
+          <span class="detail-value">{{ recipe.grain_size }}</span>
+        </div>
+      </div>
+
+      {# Color Chrome — prism for CCE, circle-with-dot for FX Blue #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+              <polygon points="7,1 13,12 1,12"/>
+              <line x1="7" y1="1" x2="4" y2="7" stroke-width="0.8" opacity="0.5"/>
+              <line x1="7" y1="1" x2="7.5" y2="5.5" stroke-width="0.8" opacity="0.5"/>
+              <line x1="7" y1="1" x2="10.5" y2="8" stroke-width="0.8" opacity="0.5"/>
+            </svg>
+            Color Chrome Effect
+          </span>
+          <span class="detail-value">{{ recipe.color_chrome_effect }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+              <circle cx="7" cy="7" r="5.5"/>
+              <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" opacity="0.6"/>
+            </svg>
+            Color Chrome FX Blue
+          </span>
+          <span class="detail-value">{{ recipe.color_chrome_fx_blue }}</span>
+        </div>
+      </div>
+
+      {# White Balance — lightbulb (colour temperature of the light source) #}
+      <div class="detail-field">
+        <span class="detail-label">
+          <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 9.5 C5 9.5 3.2 8.3 3.2 6.2 A3.8 3.8 0 0 1 10.8 6.2 C10.8 8.3 9 9.5 9 9.5 Z"/>
+            <line x1="5.2" y1="11" x2="8.8" y2="11"/>
+            <line x1="5.8" y1="12.5" x2="8.2" y2="12.5"/>
+          </svg>
+          White Balance
+        </span>
+        <span class="detail-value">{{ recipe.white_balance }}</span>
+      </div>
+
+      {# WB Shifts — warm thermometer (R) and cool thermometer (B) #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+              <line x1="2" y1="7" x2="11" y2="7"/>
+              <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+              <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">R</text>
+            </svg>
+            WB Red Shift
+          </span>
+          <span class="detail-value">{{ recipe.white_balance_red|signed }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+              <line x1="2" y1="7" x2="11" y2="7"/>
+              <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+              <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">B</text>
+            </svg>
+            WB Blue Shift
+          </span>
+          <span class="detail-value">{{ recipe.white_balance_blue|signed }}</span>
+        </div>
+      </div>
+
+      {# Dynamic Range — histogram bars / DR priority layered bars #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+              <rect x="1" y="9" width="2.5" height="4" rx="0.3"/>
+              <rect x="4.5" y="6" width="2.5" height="7" rx="0.3"/>
+              <rect x="8" y="3.5" width="2.5" height="9.5" rx="0.3"/>
+              <rect x="11.5" y="6.5" width="1.5" height="6.5" rx="0.3"/>
+            </svg>
+            Dynamic Range
+          </span>
+          <span class="detail-value">{{ recipe.dynamic_range }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+              <line x1="1" y1="4" x2="13" y2="4"/>
+              <line x1="1" y1="7" x2="10" y2="7"/>
+              <line x1="1" y1="10" x2="7" y2="10"/>
+            </svg>
+            D-Range Priority
+          </span>
+          <span class="detail-value">{{ recipe.d_range_priority }}</span>
+        </div>
+      </div>
+
+      {# Tone curve — Highlight (sun) / Shadow (moon) #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+              <circle cx="7" cy="7" r="2.2"/>
+              <line x1="7" y1="1" x2="7" y2="2"/>
+              <line x1="7" y1="12" x2="7" y2="13"/>
+              <line x1="1" y1="7" x2="2" y2="7"/>
+              <line x1="12" y1="7" x2="13" y2="7"/>
+              <line x1="2.8" y1="2.8" x2="3.5" y2="3.5"/>
+              <line x1="10.5" y1="10.5" x2="11.2" y2="11.2"/>
+              <line x1="11.2" y1="2.8" x2="10.5" y2="3.5"/>
+              <line x1="3.5" y1="10.5" x2="2.8" y2="11.2"/>
+            </svg>
+            Highlight
+          </span>
+          <span class="detail-value">{{ recipe.highlight|signed }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+              <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z" fill="currentColor" opacity="0.55" stroke="none"/>
+              <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z"/>
+            </svg>
+            Shadow
+          </span>
+          <span class="detail-value">{{ recipe.shadow|signed }}</span>
+        </div>
+      </div>
+
+      {# Color (palette) / Sharpness (diamond) #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+              <circle cx="7" cy="7" r="5.5"/>
+              <circle cx="5" cy="5.5" r="1.1" fill="currentColor" stroke="none"/>
+              <circle cx="9" cy="5" r="1.1" fill="currentColor" stroke="none"/>
+              <circle cx="10.2" cy="8.5" r="1.1" fill="currentColor" stroke="none"/>
+              <circle cx="4.2" cy="9.2" r="1.1" fill="currentColor" stroke="none"/>
+            </svg>
+            Color
+          </span>
+          <span class="detail-value">{{ recipe.color|signed }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+              <polygon points="7,1 13,7 7,13 1,7"/>
+              <polygon points="7,3.5 10.5,7 7,10.5 3.5,7" fill="currentColor" opacity="0.25" stroke="none"/>
+            </svg>
+            Sharpness
+          </span>
+          <span class="detail-value">{{ recipe.sharpness|signed }}</span>
+        </div>
+      </div>
+
+      {# NR (funnel/filter) / Clarity (concentric circles) #}
+      <div class="detail-pair">
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5 Z" fill="currentColor" opacity="0.2"/>
+              <polyline points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5 Z"/>
+            </svg>
+            High ISO NR
+          </span>
+          <span class="detail-value">{{ recipe.high_iso_nr|signed }}</span>
+        </div>
+        <div class="detail-field">
+          <span class="detail-label">
+            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+              <circle cx="7" cy="7" r="5.5"/>
+              <circle cx="7" cy="7" r="3.2"/>
+              <circle cx="7" cy="7" r="1" fill="currentColor" stroke="none"/>
+            </svg>
+            Clarity
+          </span>
+          <span class="detail-value">{{ recipe.clarity|signed }}</span>
+        </div>
+      </div>
+
+      <p class="detail-image-count">{{ recipe.image_count }} image{{ recipe.image_count|pluralize }}</p>
+    </div>
+
+    <!-- Actions -->
+    <div class="detail-actions-col">
+      <h2 class="detail-section-title">Actions</h2>
+
+      <div class="action-group">
+        {% if recipe.name %}
+          <button class="action-btn action-btn--primary send-to-camera-btn"
+                  hx-get="{% url 'select-push-slot' recipe_id=recipe.id %}"
+                  hx-target="#slot-overlay"
+                  hx-swap="innerHTML">Send to camera</button>
+        {% else %}
+          <div style="display:flex;align-items:center;gap:0.75rem;">
+            <button class="action-btn action-btn--disabled" disabled>Send to camera</button>
+            <span class="action-hint">Name the recipe first for sending it to camera.</span>
+          </div>
+        {% endif %}
+        {% if recipe.image_count %}
+          <a class="action-btn action-btn--secondary" href="{% url 'gallery' %}?recipe_id={{ recipe.id }}">Browse images</a>
+        {% endif %}
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/src/interfaces/templates/recipes/recipe_detail.html
+++ b/src/interfaces/templates/recipes/recipe_detail.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if recipe.name %}{{ recipe.name }}{% else %}{{ recipe.film_simulation }} #{{ recipe.id }}{% endif %}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; }
+    body { background: #1a1a1a; display: flex; flex-direction: column; }
+  </style>
+</head>
+<body>
+
+{% include "recipes/partials/recipe_detail.html" %}
+
+<script>
+  function closeDetail() {
+    window.location.href = document.querySelector('.detail-close').href;
+  }
+  document.querySelector('.detail-close').addEventListener('click', function (e) {
+    e.preventDefault();
+    closeDetail();
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') closeDetail();
+  });
+</script>
+
+</body>
+</html>

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -313,6 +313,62 @@
 
     .create-recipes-option:hover { background: #f5f5f5; }
 
+    /* ── Recipe detail overlay ──────────────────────────────────────── */
+    #recipe-detail-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      overflow: hidden;
+    }
+
+    #recipe-detail-overlay .detail-overlay {
+      height: 100%;
+    }
+
+    #slot-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.6);
+    }
+
+    #slot-overlay[hidden] { display: none; }
+
+    .slot-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 2rem;
+      width: 580px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+      position: relative;
+      font-family: sans-serif;
+      min-height: 120px;
+      overflow: hidden;
+    }
+
+    .slot-push-loading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 220px;
+      padding: 2rem;
+    }
+
+    .slot-spinner-large {
+      width: 80px;
+      height: 80px;
+      border: 6px solid #e0e0e0;
+      border-top-color: #2db37a;
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+    }
+
+    @keyframes slot-spin { to { transform: rotate(360deg); } }
+
     /* ── Import modal overlay ───────────────────────────────────────── */
     .import-overlay {
       position: fixed;
@@ -571,7 +627,10 @@
     });
 
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && !overlay.hidden) closeModal();
+      if (e.key !== 'Escape') return;
+      var recipeDetailOverlay = document.getElementById('recipe-detail-overlay');
+      if (recipeDetailOverlay && !recipeDetailOverlay.hidden) return;  // handled by recipe detail JS
+      if (!overlay.hidden) closeModal();
     });
 
     // Show selected files
@@ -591,6 +650,58 @@
       submitBtn.hidden = false;
     });
   })();
+</script>
+
+<div id="recipe-detail-overlay" hidden></div>
+<div id="slot-overlay" hidden></div>
+
+<script>
+  // Recipe detail overlay logic.
+  var _explorerUrl = null;
+
+  function closeSlotOverlay() {
+    document.getElementById('slot-overlay').hidden = true;
+  }
+
+  function closeRecipeDetail() {
+    document.getElementById('recipe-detail-overlay').hidden = true;
+    document.getElementById('slot-overlay').hidden = true;
+    document.querySelector('.recipe-gallery-scroll').style.overflow = '';
+    if (_explorerUrl) {
+      history.replaceState(null, '', _explorerUrl);
+      _explorerUrl = null;
+    }
+  }
+
+  window._recipeDetailClose = closeRecipeDetail;
+
+  document.body.addEventListener('htmx:beforeRequest', function (e) {
+    if (e.detail.target && e.detail.target.id === 'recipe-detail-overlay') {
+      var detailOverlay = document.getElementById('recipe-detail-overlay');
+      if (detailOverlay.hidden) _explorerUrl = window.location.href;
+    }
+  });
+
+  document.body.addEventListener('htmx:afterSwap', function (e) {
+    if (e.detail.target.id === 'recipe-detail-overlay') {
+      e.detail.target.hidden = false;
+      document.querySelector('.recipe-gallery-scroll').style.overflow = 'hidden';
+    } else if (e.detail.target.id === 'slot-overlay') {
+      e.detail.target.hidden = false;
+    }
+  });
+
+  document.getElementById('slot-overlay').addEventListener('click', function (e) {
+    if (e.target === this) closeSlotOverlay();
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Escape') return;
+    var slotOverlay = document.getElementById('slot-overlay');
+    if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
+    var detailOverlay = document.getElementById('recipe-detail-overlay');
+    if (detailOverlay && !detailOverlay.hidden) closeRecipeDetail();
+  });
 </script>
 </body>
 </html>

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -283,6 +283,17 @@ def recipes_explorer_results_view(request: http.HttpRequest) -> http.HttpRespons
     return shortcuts.render(request, "recipes/partials/htmx_scroll_response.html", {"page_obj": gallery.page_obj})
 
 
+def recipe_detail_view(request: http.HttpRequest, recipe_id: int) -> http.HttpResponse:
+    try:
+        detail = recipe_queries.get_recipe_detail(recipe_id=recipe_id)
+    except models.FujifilmRecipe.DoesNotExist:
+        raise http.Http404
+    ctx = {"recipe": detail.recipe, "is_monochromatic": detail.is_monochromatic}
+    if request.headers.get("HX-Request"):
+        return shortcuts.render(request, "recipes/partials/recipe_detail.html", ctx)
+    return shortcuts.render(request, "recipes/recipe_detail.html", ctx)
+
+
 _RECIPES_GRAPH_DEFAULT_FILM_SIM = "Provia"
 
 

--- a/tests/functional/test_recipe_detail_view.py
+++ b/tests/functional/test_recipe_detail_view.py
@@ -1,0 +1,173 @@
+import pytest
+from bs4 import BeautifulSoup
+
+from tests.factories import FujifilmRecipeFactory, ImageFactory
+
+
+@pytest.mark.django_db
+class TestRecipeDetailView:
+    def test_returns_200_for_existing_recipe(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = client.get(f"/recipes/{recipe.pk}/")
+        assert response.status_code == 200
+
+    def test_returns_404_for_missing_recipe(self, client):
+        response = client.get("/recipes/99999/")
+        assert response.status_code == 404
+
+    def test_shows_recipe_name_in_page(self, client):
+        recipe = FujifilmRecipeFactory(name="Fuji Street Look")
+        response = client.get(f"/recipes/{recipe.pk}/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "Fuji Street Look" in soup.get_text()
+
+    def test_shows_film_simulation_in_page(self, client):
+        recipe = FujifilmRecipeFactory(film_simulation="Classic Chrome")
+        response = client.get(f"/recipes/{recipe.pk}/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "Classic Chrome" in soup.get_text()
+
+    def test_shows_close_button_linking_to_explorer(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = client.get(f"/recipes/{recipe.pk}/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        close_btn = soup.find(class_="detail-close")
+        assert close_btn is not None
+        assert close_btn["href"] == "/recipes/"
+
+    def test_close_button_is_in_header(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = client.get(f"/recipes/{recipe.pk}/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        header = soup.find(class_="detail-header")
+        assert header is not None
+        assert header.find(class_="detail-close") is not None
+
+    def test_shows_recipe_settings_in_page(self, client):
+        recipe = FujifilmRecipeFactory(
+            grain_roughness="Strong",
+            grain_size="Large",
+            color_chrome_effect="Strong",
+            color_chrome_fx_blue="Weak",
+        )
+        response = client.get(f"/recipes/{recipe.pk}/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        text = soup.get_text()
+        assert "Strong" in text
+        assert "Large" in text
+        assert "Weak" in text
+
+
+@pytest.mark.django_db
+class TestRecipeDetailMonochromaticFields:
+    def _get_partial(self, client, recipe_id):
+        return client.get(f"/recipes/{recipe_id}/", HTTP_HX_REQUEST="true")
+
+    def test_monochromatic_fields_shown_for_monochromatic_film_simulation(self, client):
+        recipe = FujifilmRecipeFactory(film_simulation="Acros STD")
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        text = soup.get_text()
+        assert "BW Warm" in text
+        assert "BW Magenta" in text
+
+    def test_monochromatic_fields_hidden_for_colour_film_simulation(self, client):
+        recipe = FujifilmRecipeFactory(film_simulation="Provia")
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        text = soup.get_text()
+        assert "BW Warm" not in text
+        assert "BW Magenta" not in text
+
+
+@pytest.mark.django_db
+class TestRecipeDetailPartial:
+    def _get_partial(self, client, recipe_id):
+        return client.get(f"/recipes/{recipe_id}/", HTTP_HX_REQUEST="true")
+
+    def test_returns_200_for_existing_recipe(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = self._get_partial(client, recipe.pk)
+        assert response.status_code == 200
+
+    def test_returns_404_for_missing_recipe(self, client):
+        response = client.get("/recipes/99999/", HTTP_HX_REQUEST="true")
+        assert response.status_code == 404
+
+    def test_partial_does_not_include_html_doctype(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = self._get_partial(client, recipe.pk)
+        assert b"<!DOCTYPE" not in response.content
+
+    def test_shows_recipe_name_in_partial(self, client):
+        recipe = FujifilmRecipeFactory(name="Street Provia")
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "Street Provia" in soup.get_text()
+
+    def test_shows_film_simulation_in_partial(self, client):
+        recipe = FujifilmRecipeFactory(film_simulation="Velvia")
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert "Velvia" in soup.get_text()
+
+    def test_close_button_present_in_partial(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="detail-close") is not None
+
+    def test_send_to_camera_button_present_when_recipe_named(self, client):
+        recipe = FujifilmRecipeFactory(name="Cuban Negative")
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        btn = soup.find(class_="send-to-camera-btn")
+        assert btn is not None
+        assert btn.get("hx-get") == f"/recipes/{recipe.pk}/push/"
+
+    def test_send_to_camera_button_absent_when_recipe_unnamed(self, client):
+        recipe = FujifilmRecipeFactory(name="")
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="send-to-camera-btn") is None
+
+    def test_shows_detail_overlay_structure(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = self._get_partial(client, recipe.pk)
+        soup = BeautifulSoup(response.content, "html.parser")
+        assert soup.find(class_="detail-overlay") is not None
+        assert soup.find(class_="detail-header") is not None
+        assert soup.find(class_="detail-settings-col") is not None
+        assert soup.find(class_="detail-actions-col") is not None
+
+
+@pytest.mark.django_db
+class TestRecipeCardHtmxAttributes:
+    def test_recipe_card_has_hx_get_pointing_to_detail_url(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        card = soup.find(class_="recipe-card")
+        assert card is not None
+        assert card.get("hx-get") == f"/recipes/{recipe.pk}/"
+
+    def test_recipe_card_targets_recipe_detail_overlay(self, client):
+        FujifilmRecipeFactory()
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        card = soup.find(class_="recipe-card")
+        assert card.get("hx-target") == "#recipe-detail-overlay"
+
+    def test_recipe_card_has_hx_push_url(self, client):
+        recipe = FujifilmRecipeFactory()
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        card = soup.find(class_="recipe-card")
+        assert card.get("hx-push-url") == f"/recipes/{recipe.pk}/"
+
+    def test_explorer_page_has_recipe_detail_overlay_div(self, client):
+        response = client.get("/recipes/")
+        soup = BeautifulSoup(response.content, "html.parser")
+        overlay = soup.find(id="recipe-detail-overlay")
+        assert overlay is not None
+        assert overlay.has_attr("hidden")

--- a/tests/integration/domain/test_recipe_detail_query.py
+++ b/tests/integration/domain/test_recipe_detail_query.py
@@ -1,0 +1,103 @@
+import pytest
+
+from src.data.models import FujifilmRecipe
+from src.domain.recipes.queries import RecipeData, RecipeDetailContext, get_recipe_detail
+from src.domain.recipes.constants import MONOCHROMATIC_FILM_SIMULATIONS
+from tests.factories import FujifilmRecipeFactory, ImageFactory
+
+
+@pytest.mark.django_db
+class TestGetRecipeDetail:
+    def test_returns_recipe_detail_context(self):
+        recipe = FujifilmRecipeFactory()
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert isinstance(result, RecipeDetailContext)
+
+    def test_returns_recipe_data_for_existing_recipe(self):
+        recipe = FujifilmRecipeFactory(name="Velvet Dream", film_simulation="Velvia")
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert isinstance(result.recipe, RecipeData)
+        assert result.recipe.id == recipe.pk
+        assert result.recipe.name == "Velvet Dream"
+        assert result.recipe.film_simulation == "Velvia"
+
+    def test_raises_does_not_exist_for_missing_recipe(self):
+        with pytest.raises(FujifilmRecipe.DoesNotExist):
+            get_recipe_detail(recipe_id=99999)
+
+    def test_image_count_is_zero_when_no_images(self):
+        recipe = FujifilmRecipeFactory()
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert result.recipe.image_count == 0
+
+    def test_image_count_reflects_associated_images(self):
+        recipe = FujifilmRecipeFactory()
+        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert result.recipe.image_count == 3
+
+    def test_image_count_excludes_images_from_other_recipes(self):
+        recipe_a = FujifilmRecipeFactory()
+        recipe_b = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=recipe_a)
+        ImageFactory.create_batch(2, fujifilm_recipe=recipe_b)
+
+        result = get_recipe_detail(recipe_id=recipe_a.pk)
+
+        assert result.recipe.image_count == 1
+
+    def test_cover_image_id_is_none_when_no_images(self):
+        recipe = FujifilmRecipeFactory()
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert result.recipe.cover_image_id is None
+
+    def test_cover_image_id_is_set_when_images_exist(self):
+        recipe = FujifilmRecipeFactory()
+        image = ImageFactory(fujifilm_recipe=recipe)
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert result.recipe.cover_image_id == image.pk
+
+    def test_is_monochromatic_is_true_for_monochromatic_film_simulation(self):
+        mono_sim = next(iter(MONOCHROMATIC_FILM_SIMULATIONS))
+        recipe = FujifilmRecipeFactory(film_simulation=mono_sim)
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert result.is_monochromatic is True
+
+    def test_is_monochromatic_is_false_for_colour_film_simulation(self):
+        recipe = FujifilmRecipeFactory(film_simulation="Provia")
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+
+        assert result.is_monochromatic is False
+
+    def test_all_recipe_settings_are_returned(self):
+        recipe = FujifilmRecipeFactory(
+            dynamic_range="DR200",
+            grain_roughness="Strong",
+            grain_size="Large",
+            color_chrome_effect="Strong",
+            white_balance="Daylight",
+        )
+
+        result = get_recipe_detail(recipe_id=recipe.pk)
+        r = result.recipe
+
+        assert r.dynamic_range == "DR200"
+        assert r.grain_roughness == "Strong"
+        assert r.grain_size == "Large"
+        assert r.color_chrome_effect == "Strong"
+        assert r.white_balance == "Daylight"


### PR DESCRIPTION
## Summary

<img width="1768" height="1531" alt="image" src="https://github.com/user-attachments/assets/0bdb1f7c-5cd3-4b2c-a8db-e29c515c659e" />


- Adds a recipe detail modal view at `/recipes/<id>/` that opens as an HTMX overlay when clicking a recipe card in the explorer, mirroring the existing image gallery modal pattern
- The modal displays all recipe settings grouped in a two-column layout (film simulation, grain, colour chrome, white balance, tone curve, dynamic range, noise reduction, clarity) with inline SVG icons per field; monochromatic colour fields (BW Warm/Magenta) are shown only for Acros, Monochrome, and Sepia simulations
- Recipe name editing is inline in the header: the title text is replaced in-place by a same-styled input when "Edit recipe name" is clicked; the input is pre-filled with the current name, or empty for unnamed recipes; Escape cancels without closing the overlay
- Actions column offers: Send to camera (disabled with explanatory hint when unnamed), Browse images (links to the gallery filtered by that recipe, only shown when images exist)
- Full-page fallback renders the same partial for direct navigation to `/recipes/<id>/`; HTMX manages URL history via `hx-push-url` and restores the explorer URL on close