### PR TITLE
Add make update command and document it in the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CELERY  := $(VENV)/bin/celery
 
 ENV_FILE := src/config/env
 
-.PHONY: setup-lite setup-full env env-lite run worker test help
+.PHONY: setup-lite setup-full env env-lite update run worker test help
 
 ##
 ## Installation modes:
@@ -82,6 +82,18 @@ $(VENV)/bin/activate:
 		echo ""; \
 		exit 1; \
 	}
+
+## update      — pull latest changes, install new dependencies, and run migrations
+update:
+	@echo "[update] Pulling latest changes..."
+	@git pull origin main
+	@echo "[update] Installing dependencies..."
+	@$(PIP) install --quiet -r requirements.txt
+	@touch $(VENV)/.deps-installed
+	@echo "[update] Running database migrations..."
+	@$(PYTHON) manage.py migrate
+	@echo ""
+	@echo "Done. Run 'make run' to start the server."
 
 ## run         — start the Django development server
 run:

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Read more about it in our [documentation index](docs/index.md).
 
 Two installation modes are available depending on your needs:
 
-| | Lite (user-only) | Full (developer) |
-|---|---|---|
-| **Database** | SQLite (file, no server) | PostgreSQL |
-| **Broker / worker** | None | RabbitMQ + Celery |
-| **Image processing** | Sequential (one at a time) | Parallel (N workers) |
-| **OS services to install** | None | PostgreSQL, RabbitMQ |
-| **Best for** | Personal use, small libraries | Development, large collections |
+|                            | Lite (user-only)              | Full (developer)               |
+| -------------------------- | ----------------------------- | ------------------------------ |
+| **Database**               | SQLite (file, no server)      | PostgreSQL                     |
+| **Broker / worker**        | None                          | RabbitMQ + Celery              |
+| **Image processing**       | Sequential (one at a time)    | Parallel (N workers)           |
+| **OS services to install** | None                          | PostgreSQL, RabbitMQ           |
+| **Best for**               | Personal use, small libraries | Development, large collections |
 
 ### Lite install (recommended for personal use)
 
@@ -48,6 +48,7 @@ cd film_simulations_reader
 ```bash
 make setup-lite   # creates venv, installs deps, generates SQLite config, runs migrations
 make run          # start the development server
+make update       # pull latest changes, install new deps, run migrations
 ```
 
 Images are processed sequentially when you run `python manage.py process_images`. No
@@ -78,7 +79,16 @@ make setup-full   # creates venv, installs deps, generates PostgreSQL config, ru
 ```bash
 make run      # start the Django development server
 make worker   # start a Celery worker for parallel image processing
-make test     # run the test suite
+```
+
+---
+
+## Updating
+
+To pull the latest changes, install any new dependencies, and apply pending migrations in one step:
+
+```bash
+make update
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds a `make update` target to the Makefile that runs `git pull origin main`, `pip install -r requirements.txt` (via the project venv), and `python manage.py migrate` in sequence
- Adds an **Updating** section to the README, placed between the install modes and the manual setup section, so end users find it easily without wading through developer-facing content
- References `make update` in the lite install quick-start command block for discoverability
