### PR TITLE
Add type linting

### DIFF
--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -1,0 +1,25 @@
+name: Types
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run mypy
+        run: mypy src/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ import-linter==2.11
 grimp==3.14
 
 # Type checking
+mypy==1.15.0
 django-stubs==5.2.9
 django-stubs-ext==5.2.9
 
@@ -19,4 +20,5 @@ pdbpp==0.12.1
 ipython==9.11.0
 
 # Type stubs
+celery-types==0.26.0
 types-PyYAML==6.0.12.20250915

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,22 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+strict = True
+warn_unreachable = True
+enable_error_code = ignore-without-code
+
+[mypy.plugins.django-stubs]
+django_settings_module = src.config.settings
+
+[mypy-envparse]
+ignore_missing_imports = True
+
+[mypy-usb]
+ignore_missing_imports = True
+
+[mypy-usb.*]
+ignore_missing_imports = True
+
 [importlinter]
 root_packages =
     src

--- a/src/application/usecases/images/compare_recipes.py
+++ b/src/application/usecases/images/compare_recipes.py
@@ -1,8 +1,6 @@
 # This module has been superseded by src.domain.recipes.queries.
 # Re-exported here to avoid breaking the compare_recipes management command.
-from src.domain.recipes.queries import (  # noqa: F401
-    RECIPE_FIELDS,
-    RecipeComparisonResult,
-    RecipeUsageStats,
-    get_recipe_comparison,
-)
+from src.domain.recipes.queries import RECIPE_FIELDS as RECIPE_FIELDS
+from src.domain.recipes.queries import RecipeComparisonResult as RecipeComparisonResult
+from src.domain.recipes.queries import RecipeUsageStats as RecipeUsageStats
+from src.domain.recipes.queries import get_recipe_comparison as get_recipe_comparison

--- a/src/data/migrations/0007_populate_and_remove_recipe_fields_from_image.py
+++ b/src/data/migrations/0007_populate_and_remove_recipe_fields_from_image.py
@@ -1,5 +1,7 @@
 # Generated manually on 2026-03-12
 
+from typing import Any
+
 from django.db import migrations
 
 _RECIPE_FIELDS = [
@@ -22,7 +24,7 @@ _RECIPE_FIELDS = [
 ]
 
 
-def populate_recipes(apps, schema_editor):
+def populate_recipes(apps: Any, schema_editor: Any) -> None:
     Image = apps.get_model("data", "Image")
     FujifilmRecipe = apps.get_model("data", "FujifilmRecipe")
     for combo in Image.objects.values(*_RECIPE_FIELDS).distinct():

--- a/src/data/migrations/0024_image_rating_default.py
+++ b/src/data/migrations/0024_image_rating_default.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from django.db import migrations, models
 
 
-def _set_null_ratings_to_zero(apps, schema_editor):
+def _set_null_ratings_to_zero(apps: Any, schema_editor: Any) -> None:
     Image = apps.get_model("data", "Image")
     Image.objects.filter(rating__isnull=True).update(rating=0)
 

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.db import models
 from django.utils import timezone
 
@@ -155,15 +157,15 @@ class FujifilmExif(models.Model):
     # Factories
 
     @classmethod
-    def get_or_create(cls, **fields) -> "FujifilmExif":
-        obj, _ = cls.objects.get_or_create(**fields)  # type: ignore[attr-defined]
+    def get_or_create(cls, **fields: Any) -> "FujifilmExif":
+        obj, _ = cls.objects.get_or_create(**fields)
         return obj
 
     # Properties
 
-    def __str__(self):
+    def __str__(self) -> str:
         label = self.name or self.film_simulation or "Unknown"
-        return f"#{self.id} {label}"  # type: ignore[attr-defined]
+        return f"#{self.id} {label}"
 
 
 class FujifilmRecipe(models.Model):
@@ -236,7 +238,7 @@ class FujifilmRecipe(models.Model):
         monochromatic_color_warm_cool: object,
         monochromatic_color_magenta_green: object,
     ) -> "tuple[FujifilmRecipe, bool]":
-        return cls.objects.get_or_create(  # type: ignore[attr-defined]
+        return cls.objects.get_or_create(
             film_simulation=film_simulation,
             dynamic_range=dynamic_range,
             d_range_priority=d_range_priority,
@@ -265,11 +267,11 @@ class FujifilmRecipe(models.Model):
 
     # Properties
 
-    def __str__(self):
-        return f"#{self.id} {self.name}"  # type: ignore[attr-defined]
+    def __str__(self) -> str:
+        return f"#{self.id} {self.name}"
 
 
-class ImageQuerySet(models.QuerySet):
+class ImageQuerySet(models.QuerySet["Image"]):
     def without_recipe(self) -> "ImageQuerySet":
         return self.filter(fujifilm_recipe__isnull=True)
 
@@ -336,16 +338,16 @@ class Image(models.Model):
     # Factories
 
     @classmethod
-    def update_or_create(cls, *, filepath: str, **defaults) -> tuple["Image", bool]:
+    def update_or_create(cls, *, filepath: str, **defaults: object) -> tuple["Image", bool]:
         return cls.objects.update_or_create(filepath=filepath, defaults=defaults)
 
     # Mutators
 
-    def set_as_favorite(self):
+    def set_as_favorite(self) -> None:
         self.is_favorite = True
         self.save(update_fields=["is_favorite"])
 
-    def set_as_in_album(self):
+    def set_as_in_album(self) -> None:
         self.in_album = True
         self.save(update_fields=["in_album"])
 
@@ -355,5 +357,5 @@ class Image(models.Model):
 
     # Properties
 
-    def __str__(self):
-        return f"#{self.id} {self.filename}"  # type: ignore[attr-defined]
+    def __str__(self) -> str:
+        return f"#{self.id} {self.filename}"

--- a/src/domain/camera/device_config.py
+++ b/src/domain/camera/device_config.py
@@ -6,6 +6,7 @@ settings.PTP_DEVICE may be a dotted import path (str) or a callable directly.
 from __future__ import annotations
 
 import importlib
+from typing import cast
 
 from django.conf import settings as django_settings
 
@@ -18,4 +19,5 @@ def get_device() -> ptp_device.PTPDevice:
     if isinstance(factory, str):
         module_path, cls_name = factory.rsplit(".", 1)
         factory = getattr(importlib.import_module(module_path), cls_name)
-    return factory()
+    assert callable(factory)
+    return cast(ptp_device.PTPDevice, factory())

--- a/src/domain/camera/ptp_usb_device.py
+++ b/src/domain/camera/ptp_usb_device.py
@@ -148,7 +148,7 @@ def _skip_ptp_uint16_array(data: bytes, offset: int) -> int:
     """Skip a PTP uint16 array (uint32 count + count × uint16)."""
     if offset + 4 > len(data):
         return offset
-    count = struct.unpack_from("<I", data, offset)[0]
+    count: int = struct.unpack_from("<I", data, offset)[0]
     return offset + 4 + count * 2
 
 
@@ -320,7 +320,7 @@ class PTPUSBDevice:
         # Most Fuji recipe properties are uint16; read as uint32 if 4 bytes available.
         payload = data[12:]
         if len(payload) >= 4:
-            value = struct.unpack_from("<i", payload, 0)[0]  # signed int32
+            value: int = struct.unpack_from("<i", payload, 0)[0]  # signed int32
         elif len(payload) >= 2:
             value = struct.unpack_from("<H", payload, 0)[0]  # uint16
         elif len(payload) >= 1:

--- a/src/domain/camera/queries.py
+++ b/src/domain/camera/queries.py
@@ -374,7 +374,7 @@ def recipe_to_ptp_values(recipe: image_dataclasses.FujifilmRecipeData) -> Recipe
     if drp and drp != "Off":
         dr_mode: int | None = None
     else:
-        dr_mode = constants.DRANGE_MODE_TO_PTP.get(recipe.dynamic_range) if recipe.dynamic_range not in (None, "") else None
+        dr_mode = constants.DRANGE_MODE_TO_PTP.get(recipe.dynamic_range) if recipe.dynamic_range is not None and recipe.dynamic_range != "" else None
 
     # --- Grain effect (always written) ---
     # Write 1 for any Off roughness; camera normalises to 6 (Off+Small) or
@@ -390,12 +390,12 @@ def recipe_to_ptp_values(recipe: image_dataclasses.FujifilmRecipeData) -> Recipe
     cfx: int = _CFX_TO_PTP.get(recipe.color_chrome_fx_blue, _CFX_TO_PTP["Off"])
 
     # --- Scaled int16 fields (value × 10) ---
-    color = int(recipe.color) * 10 if recipe.color not in (None, "") else None
+    color = int(recipe.color) * 10 if recipe.color is not None and recipe.color != "" else None
     # Sharpness and clarity always written; unset → 0 (normal)
     sharpness: int = int(recipe.sharpness) * 10 if recipe.sharpness not in (None, "", "N/A") else 0
     # Half-step values possible (e.g. +1.5); round after ×10.
-    highlight = round(float(recipe.highlight) * 10) if recipe.highlight not in (None, "") else None
-    shadow = round(float(recipe.shadow) * 10) if recipe.shadow not in (None, "") else None
+    highlight = round(float(recipe.highlight) * 10) if recipe.highlight is not None and recipe.highlight != "" else None
+    shadow = round(float(recipe.shadow) * 10) if recipe.shadow is not None and recipe.shadow != "" else None
     clarity: int = int(recipe.clarity) * 10 if recipe.clarity not in (None, "", "N/A") else 0
 
     # --- High ISO noise reduction (non-linear lookup; always written; unset → 0/normal) ---
@@ -403,8 +403,8 @@ def recipe_to_ptp_values(recipe: image_dataclasses.FujifilmRecipeData) -> Recipe
 
     # --- Monochromatic colour tuning (int16 ÷ 10; confirmed 2026-03-26 X-S10) ---
     # None when film sim is not monochromatic (field not applicable).
-    mono_wc = round(float(recipe.monochromatic_color_warm_cool) * 10) if recipe.monochromatic_color_warm_cool not in (None, "") else None
-    mono_mg = round(float(recipe.monochromatic_color_magenta_green) * 10) if recipe.monochromatic_color_magenta_green not in (None, "") else None
+    mono_wc = round(float(recipe.monochromatic_color_warm_cool) * 10) if recipe.monochromatic_color_warm_cool is not None and recipe.monochromatic_color_warm_cool != "" else None
+    mono_mg = round(float(recipe.monochromatic_color_magenta_green) * 10) if recipe.monochromatic_color_magenta_green is not None and recipe.monochromatic_color_magenta_green != "" else None
 
     return RecipePTPValues(
         FilmSimulation=film_sim,

--- a/src/domain/images/dataclasses.py
+++ b/src/domain/images/dataclasses.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import attrs
 
 RECIPE_NAME_MAX_LEN = 25
 
 
-def _validate_name(instance, attribute, value):
+def _validate_name(instance: object, attribute: attrs.Attribute[str], value: str) -> None:
     if value and (len(value) > RECIPE_NAME_MAX_LEN or not value.isascii()):
         raise ValueError(
             f"Recipe name must be ≤{RECIPE_NAME_MAX_LEN} ASCII characters, got {value!r}"

--- a/src/domain/images/filter_queries.py
+++ b/src/domain/images/filter_queries.py
@@ -1,4 +1,5 @@
 import attrs
+from collections.abc import Mapping, Sequence
 
 from django.core import paginator as django_paginator
 from django.db import models as db_models
@@ -22,8 +23,8 @@ RECIPE_FILTER_FIELDS = [
 
 
 def get_sidebar_filter_options(
-    active_filters: dict[str, list[str]],
-) -> dict[str, dict]:
+    active_filters: Mapping[str, Sequence[str]],
+) -> dict[str, dict[str, object]]:
     """
     Compute faceted sidebar options for all recipe filter fields.
 
@@ -45,7 +46,7 @@ def get_sidebar_filter_options(
             options  – list of dicts: value, count, available, selected
             selected – list of currently selected string values for this field
     """
-    result = {}
+    result: dict[str, dict[str, object]] = {}
 
     for field, label in RECIPE_FILTER_FIELDS:
         model_field = models.FujifilmRecipe._meta.get_field(field)
@@ -83,7 +84,7 @@ def get_sidebar_filter_options(
             )
         }
 
-        selected_values: list[str] = active_filters.get(field, [])
+        selected_values: Sequence[str] = active_filters.get(field, [])
 
         # Union of available values and selected-but-unavailable values.
         all_values: set[str] = set(available_counts.keys()) | set(selected_values)
@@ -91,7 +92,7 @@ def get_sidebar_filter_options(
         # Sort: available values first, then unavailable; within each group
         # sort numerically for integer fields, alphabetically for text fields.
         if is_integer:
-            def _sort_key(v: str) -> tuple:
+            def _sort_key(v: str) -> tuple[int, int]:
                 try:
                     return (0 if v in available_counts else 1, int(v))
                 except (ValueError, TypeError):
@@ -122,9 +123,9 @@ def get_sidebar_filter_options(
 
 def get_filtered_images(
     *,
-    active_filters: dict[str, list[str]],
+    active_filters: Mapping[str, Sequence[str]],
     rating_first: bool,
-) -> db_models.QuerySet:
+) -> db_models.QuerySet[models.Image]:
     qs = models.Image.objects.select_related("fujifilm_recipe")
     recipe_ids = active_filters.get("recipe_id", [])
     if recipe_ids:
@@ -140,9 +141,9 @@ def get_filtered_images(
 
 def _recipe_options(
     *,
-    active_filters: dict[str, list[str]],
-    active_field_filters: dict[str, list[str]],
-) -> dict:
+    active_filters: Mapping[str, Sequence[str]],
+    active_field_filters: Mapping[str, Sequence[str]],
+) -> dict[str, object]:
     selected = active_filters.get("recipe_id", [])
 
     filtered_qs = models.Image.objects.filter(fujifilm_recipe__isnull=False)
@@ -182,13 +183,13 @@ def _recipe_options(
 @attrs.frozen
 class GalleryData:
     page_obj: object
-    sidebar_options: dict
-    recipe_options: dict
+    sidebar_options: dict[str, dict[str, object]]
+    recipe_options: dict[str, object]
 
 
 def get_gallery_data(
     *,
-    active_filters: dict[str, list[str]],
+    active_filters: Mapping[str, Sequence[str]],
     rating_first: bool,
     page_number: int | str,
     page_size: int,

--- a/src/domain/images/operations.py
+++ b/src/domain/images/operations.py
@@ -5,7 +5,7 @@ from django import conf
 
 from src.data import models
 from src.domain.images import events, queries
-from src.domain.images.queries import NoFilmSimulationError  # noqa: F401 — re-exported
+from src.domain.images.queries import NoFilmSimulationError as NoFilmSimulationError
 from src.domain.recipes import operations as recipe_operations
 
 

--- a/src/domain/images/queries.py
+++ b/src/domain/images/queries.py
@@ -1,6 +1,7 @@
 import attrs
 import os
 import re
+from collections.abc import Mapping, Sequence
 import subprocess
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -167,7 +168,7 @@ def parse_exif_date(*, value: str) -> datetime | None:
 
 def _normalize_wb_fine_tune(*, raw: str) -> str:
     """Divide exiftool White Balance Fine Tune values by 20 to get camera values."""
-    def _divide(m: re.Match) -> str:
+    def _divide(m: re.Match[str]) -> str:
         return f"{m.group(1)} {int(m.group(2)) // 20:+d}"
     return _WB_FINE_TUNE_RE.sub(_divide, raw)
 
@@ -336,7 +337,7 @@ class ImageDetailContext:
 def get_image_detail(
     *,
     image_id: int,
-    active_filters: dict[str, list[str]],
+    active_filters: Mapping[str, Sequence[str]],
     rating_first: bool,
 ) -> ImageDetailContext:
     """Fetch an image and its prev/next neighbours within the filtered image sequence.

--- a/src/domain/images/recipe_values.py
+++ b/src/domain/images/recipe_values.py
@@ -254,7 +254,7 @@ def white_balance_from_exif(*, white_balance: str, color_temperature: str) -> st
     wb = WhiteBalance(white_balance)
     if wb == WhiteBalance.KELVIN:
         return f"{color_temperature}K"
-    return wb.value
+    return str(wb.value)
 
 
 def white_balance_fine_tune_from_exif(*, white_balance_fine_tune: str) -> tuple[int, int]:

--- a/src/domain/images/thumbnails/operations.py
+++ b/src/domain/images/thumbnails/operations.py
@@ -48,14 +48,15 @@ def generate_thumbnail(*, original_path: Path, width: int) -> Path:
         # Apply EXIF orientation manually — avoids a second .load() call that
         # ImageOps.exif_transpose() would trigger internally.
         transpose_method = _ORIENTATION_TO_TRANSPOSE.get(orientation)
+        image: PILImage.Image = img
         if transpose_method is not None:
-            img = img.transpose(transpose_method)
+            image = image.transpose(transpose_method)
 
-        if img.width > width:
-            new_height = int(img.height * width / img.width)
-            img = img.resize((width, new_height), PILImage.Resampling.LANCZOS)
+        if image.width > width:
+            new_height = int(image.height * width / image.width)
+            image = image.resize((width, new_height), PILImage.Resampling.LANCZOS)
 
-        img.save(cache_path, format=fmt)
+        image.save(cache_path, format=fmt)
     return cache_path
 
 

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 import attrs
 from django.core import paginator as django_paginator
@@ -131,8 +135,8 @@ def recipe_from_db(*, recipe: models.FujifilmRecipe) -> image_dataclasses.Fujifi
 class RecipeUsageStats:
     recipe_id: int
     photo_count: int
-    first_used: object  # datetime | None
-    last_used: object  # datetime | None
+    first_used: datetime | None
+    last_used: datetime | None
 
 
 @attrs.frozen
@@ -487,7 +491,7 @@ def get_recipe_sidebar_filter_options(
     *,
     active_filters: Mapping[str, Sequence[str]],
     name_search: str = "",
-) -> dict[str, dict]:
+) -> dict[str, dict[str, object]]:
     """Return faceted filter options for the recipe explorer sidebar.
 
     For each field in RECIPE_FILTER_FIELDS, counts the number of recipes matching
@@ -496,7 +500,7 @@ def get_recipe_sidebar_filter_options(
 
     *name_search* is applied to all facet counts so they reflect the current search.
     """
-    result = {}
+    result: dict[str, dict[str, object]] = {}
     for field, label in filter_queries.RECIPE_FILTER_FIELDS:
         model_field = models.FujifilmRecipe._meta.get_field(field)
         is_integer = isinstance(model_field, db_models.IntegerField)
@@ -521,7 +525,7 @@ def get_recipe_sidebar_filter_options(
         all_values: set[str] = set(available_counts) | set(selected_values)
 
         if is_integer:
-            def _sort_key(v: str) -> tuple:
+            def _sort_key(v: str) -> tuple[int, int]:
                 try:
                     return (0 if v in available_counts else 1, int(v))
                 except (ValueError, TypeError):
@@ -561,7 +565,7 @@ class RecipeGalleryPage:
 @attrs.frozen
 class RecipeGalleryData:
     page_obj: RecipeGalleryPage
-    sidebar_options: dict
+    sidebar_options: dict[str, dict[str, object]]
 
 
 def get_recipe_gallery_data(

--- a/src/interfaces/apps.py
+++ b/src/interfaces/apps.py
@@ -6,7 +6,7 @@ class InterfacesConfig(AppConfig):
     name = "src.interfaces"
     label = "interfaces"
 
-    def ready(self):
+    def ready(self) -> None:
         import structlog
         from django.conf import settings
 

--- a/src/interfaces/management/commands/camera_info.py
+++ b/src/interfaces/management/commands/camera_info.py
@@ -23,7 +23,9 @@ Camera setup:
     Most Fujifilm bodies: MENU → CONNECTION SETTING → USB SETTING.
 """
 
-from django.core.management.base import BaseCommand
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
 
 from src.application.usecases.camera import get_camera_info as get_camera_info_uc
 from src.domain.camera import ptp_device
@@ -32,7 +34,7 @@ from src.domain.camera import ptp_device
 class Command(BaseCommand):
     help = "Read camera identity and status over USB (read-only connectivity test)."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
             "--slots",
             action="store_true",
@@ -40,7 +42,7 @@ class Command(BaseCommand):
             help="Also read the contents of each custom slot (C1–Cn).",
         )
 
-    def handle(self, *args, **options):
+    def handle(self, *args: object, **options: Any) -> None:
         self.stdout.write("Connecting to camera via USB…")
 
         try:

--- a/src/interfaces/management/commands/compare_recipes.py
+++ b/src/interfaces/management/commands/compare_recipes.py
@@ -1,4 +1,6 @@
-from django.core.management.base import BaseCommand
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
 
 from src.application.usecases.images import compare_recipes as compare_recipes_uc
 from src.application.usecases.images.compare_recipes import RECIPE_FIELDS
@@ -7,10 +9,10 @@ from src.application.usecases.images.compare_recipes import RECIPE_FIELDS
 class Command(BaseCommand):
     help = "Compare multiple recipes by ID and show their settings and usage periods."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("recipe_ids", nargs="+", type=int, help="Recipe IDs to compare")
 
-    def handle(self, *args, **options):
+    def handle(self, *args: object, **options: Any) -> None:
         ids = options["recipe_ids"]
         result = compare_recipes_uc.get_recipe_comparison(recipe_ids=ids)
 
@@ -52,9 +54,11 @@ class Command(BaseCommand):
             s = result.stats_by_id.get(r.id)
             self.stdout.write(f"\nRecipe {r.id} ({r.name or 'unnamed'}):")
             if s:
+                first = s.first_used.strftime('%Y-%m-%d') if s.first_used else "unknown"
+                last = s.last_used.strftime('%Y-%m-%d') if s.last_used else "unknown"
                 self.stdout.write(f"  Photos:     {s.photo_count}")
-                self.stdout.write(f"  First used: {s.first_used.strftime('%Y-%m-%d')}")
-                self.stdout.write(f"  Last used:  {s.last_used.strftime('%Y-%m-%d')}")
+                self.stdout.write(f"  First used: {first}")
+                self.stdout.write(f"  Last used:  {last}")
             else:
                 self.stdout.write("  No images with date_taken found.")
 

--- a/src/interfaces/management/commands/fix_empty_grain_recipes.py
+++ b/src/interfaces/management/commands/fix_empty_grain_recipes.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.core.management.base import BaseCommand
 
 from src.application.usecases.recipes import fix_empty_grain_recipes as fix_uc
@@ -10,7 +12,7 @@ class Command(BaseCommand):
         "correct row, with images reassigned before deletion."
     )
 
-    def handle(self, *args, **options):
+    def handle(self, *args: object, **options: Any) -> None:
         result = fix_uc.fix_empty_grain_recipes()
 
         for recipe_id in result.updated_in_place:

--- a/src/interfaces/management/commands/generate_thumbnails.py
+++ b/src/interfaces/management/commands/generate_thumbnails.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.core.management.base import BaseCommand
 
 from src.application.usecases.images import generate_thumbnails
@@ -8,7 +10,7 @@ THUMBNAIL_WIDTH = 600
 class Command(BaseCommand):
     help = "Pre-generate thumbnail cache for all images."
 
-    def handle(self, *args, **options):
+    def handle(self, *args: object, **options: Any) -> None:
         self.stdout.write(f"Generating thumbnails at width={THUMBNAIL_WIDTH}px…")
 
         result = generate_thumbnails.generate_thumbnails_for_all_images(width=THUMBNAIL_WIDTH)

--- a/src/interfaces/management/commands/process_images.py
+++ b/src/interfaces/management/commands/process_images.py
@@ -1,5 +1,7 @@
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
 
 from src.application.usecases.images import process_images
 
@@ -7,10 +9,10 @@ from src.application.usecases.images import process_images
 class Command(BaseCommand):
     help = "Import images from a folder. Enqueues Celery tasks (full stack) or processes sequentially (lite install)."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("folder", type=str, help="Path to the folder containing images.")
 
-    def handle(self, *args, **options):
+    def handle(self, *args: object, **options: Any) -> None:
         folder = options["folder"]
         self.stdout.write(f"Scanning {folder} for JPG files…")
 

--- a/src/interfaces/management/commands/rate_images.py
+++ b/src/interfaces/management/commands/rate_images.py
@@ -1,4 +1,6 @@
-from django.core.management.base import BaseCommand
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
 
 from src.application.usecases.images import rate_images
 
@@ -6,11 +8,11 @@ from src.application.usecases.images import rate_images
 class Command(BaseCommand):
     help = "Rate images in the given folder with the specified rating."
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("folder", type=str, help="Path to the folder containing images to rate.")
         parser.add_argument("--rating", type=int, required=True, help="Rating to apply to each image.")
 
-    def handle(self, *args, **options):
+    def handle(self, *args: object, **options: Any) -> None:
         folder = options["folder"]
         rating = options["rating"]
         self.stdout.write(f"Scanning {folder} for JPG files…")

--- a/src/interfaces/tasks.py
+++ b/src/interfaces/tasks.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 from celery import shared_task
 from django.conf import settings
@@ -8,7 +9,7 @@ from src.domain.images.thumbnails import operations as thumbnail_operations
 
 
 @shared_task(name="domain.process_image", bind=True, queue=settings.PROCESS_IMAGE_QUEUE)
-def process_image_task(self, *, image_path: str, **kwargs) -> str:
+def process_image_task(self: Any, /, *, image_path: str, **kwargs: object) -> str:
     """Celery task that processes a single image and stores its recipe in DB."""
     events.publish_event(
         event_type=events.TASK_IMAGE_STARTED,
@@ -29,7 +30,7 @@ def process_image_task(self, *, image_path: str, **kwargs) -> str:
 
 
 @shared_task(name="domain.generate_thumbnail", bind=True, queue=settings.PROCESS_IMAGE_QUEUE)
-def generate_thumbnail_task(self, *, filepath: str, width: int, **kwargs) -> str:
+def generate_thumbnail_task(self: Any, /, *, filepath: str, width: int, **kwargs: object) -> str:
     """Celery task that generates a thumbnail for a single image file."""
     thumbnail_operations.generate_thumbnail(original_path=Path(filepath), width=width)
     return f"Generated thumbnail for {Path(filepath).name}"

--- a/src/interfaces/templatetags/image_filters.py
+++ b/src/interfaces/templatetags/image_filters.py
@@ -4,13 +4,13 @@ register = template.Library()
 
 
 @register.filter
-def stars(value):
+def stars(value: int) -> str:
     """Return a string of filled star characters for a given integer rating."""
     return "★" * int(value)
 
 
 @register.filter
-def signed(value):
+def signed(value: int | None) -> str:
     """Format an integer with an explicit sign: +2, 0, -2."""
     if value is None:
         return "0"

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 import structlog
+from typing import Any
 from pathlib import Path
 
 from django.conf import settings
@@ -25,7 +26,7 @@ from src.domain.recipes import operations as recipe_operations
 from src.domain.recipes import queries as recipe_queries
 
 
-def _active_filters_from_request(request) -> dict[str, list[str]]:
+def _active_filters_from_request(request: http.HttpRequest) -> dict[str, list[str]]:
     filters = {
         field: request.GET.getlist(field)
         for field, _ in filter_queries.RECIPE_FILTER_FIELDS
@@ -37,7 +38,7 @@ def _active_filters_from_request(request) -> dict[str, list[str]]:
     return filters
 
 
-def gallery_view(request):
+def gallery_view(request: http.HttpRequest) -> http.HttpResponse:
     active_filters = _active_filters_from_request(request)
     rating_first = request.GET.get("rating_first", "1") == "1"
     gallery = filter_queries.get_gallery_data(
@@ -64,7 +65,7 @@ def gallery_view(request):
     )
 
 
-def image_detail_view(request, image_id):
+def image_detail_view(request: http.HttpRequest, image_id: int) -> http.HttpResponse:
     max_rating = settings.IMAGE_MAX_RATING
     rating_range = range(1, max_rating + 1)
     if request.headers.get("HX-Request"):
@@ -96,7 +97,7 @@ def image_detail_view(request, image_id):
     })
 
 
-def gallery_results_view(request):
+def gallery_results_view(request: http.HttpRequest) -> http.HttpResponse:
     active_filters = _active_filters_from_request(request)
     rating_first = request.GET.get("rating_first", "1") == "1"
     qs = filter_queries.get_filtered_images(active_filters=active_filters, rating_first=rating_first)
@@ -104,7 +105,7 @@ def gallery_results_view(request):
     return shortcuts.render(request, "images/_gallery_htmx_scroll_response.html", {"page_obj": page_obj})
 
 
-def image_file_view(request, image_id):
+def image_file_view(request: http.HttpRequest, image_id: int) -> http.HttpResponseBase:
     image = shortcuts.get_object_or_404(models.Image, pk=image_id)
     path = Path(image.filepath)
     if not path.is_file():
@@ -121,7 +122,7 @@ def image_file_view(request, image_id):
 
 
 @http_decorators.require_POST
-def set_image_rating_view(request, image_id):
+def set_image_rating_view(request: http.HttpRequest, image_id: int) -> http.HttpResponse:
     try:
         image = models.Image.objects.get(pk=image_id)
     except models.Image.DoesNotExist:
@@ -152,14 +153,14 @@ _SLOT_TO_INDEX = {"C1": 1, "C2": 2, "C3": 3, "C4": 4, "C5": 5, "C6": 6, "C7": 7}
 
 
 class SelectSlot(generic.View):
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: http.HttpRequest, *args: object, **kwargs: Any) -> http.HttpResponseBase:
         recipe = shortcuts.get_object_or_404(models.FujifilmRecipe, pk=kwargs["recipe_id"])
         if not recipe.name:
             raise http.Http404
         self.recipe = recipe
         return super().dispatch(request, *args, **kwargs)
 
-    def get(self, request, recipe_id):
+    def get(self, request: http.HttpRequest, recipe_id: int) -> http.HttpResponse:
         is_htmx = request.headers.get("HX-Request")
         try:
             states = get_camera_slots_uc.get_camera_slots()
@@ -182,7 +183,7 @@ class SelectSlot(generic.View):
 
 
 class PushRecipeToCamera(generic.View):
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: http.HttpRequest, *args: object, **kwargs: Any) -> http.HttpResponseBase:
         self.recipe = shortcuts.get_object_or_404(models.FujifilmRecipe, pk=kwargs["recipe_id"])
         slot_index = _SLOT_TO_INDEX.get(kwargs["slot"])
         if slot_index is None:
@@ -190,7 +191,7 @@ class PushRecipeToCamera(generic.View):
         self.slot_index = slot_index
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request, recipe_id, slot):
+    def post(self, request: http.HttpRequest, recipe_id: int, slot: str) -> http.HttpResponse:
         is_htmx = request.headers.get("HX-Request")
         error_ctx = {"recipe_id": recipe_id, "slot": slot}
         try:
@@ -222,11 +223,11 @@ class PushRecipeToCamera(generic.View):
 
 
 class SetRecipeName(generic.View):
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch(self, request: http.HttpRequest, *args: object, **kwargs: Any) -> http.HttpResponseBase:
         self.recipe = shortcuts.get_object_or_404(models.FujifilmRecipe, pk=kwargs["recipe_id"])
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request, recipe_id):
+    def post(self, request: http.HttpRequest, recipe_id: int) -> http.HttpResponse:
         name = request.POST.get("name", "").strip()
         try:
             recipe_operations.set_recipe_name(recipe=self.recipe, name=name)
@@ -249,7 +250,7 @@ class SetRecipeName(generic.View):
 
 
 class SetRecipeCoverImage(generic.View):
-    def post(self, request, recipe_id, image_id):
+    def post(self, request: http.HttpRequest, recipe_id: int, image_id: int) -> http.HttpResponse:
         try:
             recipe_operations.set_cover_image_for_recipe(recipe_id=recipe_id, image_id=image_id)
         except (
@@ -472,7 +473,7 @@ def import_recipes_from_uploaded_files_view(request: http.HttpRequest) -> http.H
         )
 
     files = [
-        import_recipes_uc.UploadedFile(name=f.name, content=f.read())
+        import_recipes_uc.UploadedFile(name=f.name or "", content=f.read())
         for f in uploaded
     ]
 
@@ -523,7 +524,7 @@ def recipe_path_deltas_view(request: http.HttpRequest) -> http.HttpResponse:
     })
 
 
-def _resized_image_response(path: Path, width: int):
+def _resized_image_response(path: Path, width: int) -> http.FileResponse:
     cache_path, content_type = thumbnail_operations.generate_thumbnail_with_content_type(original_path=path, width=width)
     response = http.FileResponse(cache_path.open("rb"), content_type=content_type)
     response["Cache-Control"] = "max-age=86400"


### PR DESCRIPTION
## Add strict mypy type checking

### Summary

- Installed `mypy` with strict mode and configured it in `setup.cfg` with `django-stubs`, `celery-types`, and per-module `ignore_missing_imports` for unstubbed packages (`envparse`, `pyusb`)
- Fixed all type errors across the codebase, covering 7 categories: missing annotations, implicit re-exports, type narrowing, `Any` usage, Django/Celery interface types, PIL image type mismatches, and stale `# type: ignore` comments
- Used `Mapping`/`Sequence` for input parameters, added explicit collection type annotations, `TYPE_CHECKING` guards, and avoided bare `Any` except at true boundaries (Django management commands, Celery tasks)
- Added a GitHub Actions workflow (`.github/workflows/types.yml`) that runs `mypy src/` on every push and pull request to `main`, blocking merges on type errors

### Files changed

**mypy setup**
- `requirements-dev.txt` — added `mypy==1.15.0`, `celery-types==0.26.0`
- `setup.cfg` — added `[mypy]` block with strict mode, django-stubs plugin, and per-module ignores

**type error fixes**
- `src/data/models.py` — annotated `__str__`, factory methods, mutators; parameterised `ImageQuerySet`
- `src/data/migrations/` — annotated `apps`/`schema_editor` as `Any` in two data migrations
- `src/domain/camera/queries.py` — replaced `not in (None, "")` with `is not None and x != ""` for narrowing
- `src/domain/camera/device_config.py` — added `cast()` for `PTPDevice` factory return
- `src/domain/camera/ptp_usb_device.py` — annotated `struct.unpack_from` results to narrow from `Any`
- `src/domain/images/dataclasses.py` — added `from __future__ import annotations`; typed attrs validator
- `src/domain/images/filter_queries.py` — `Mapping`/`Sequence` inputs; explicit result annotation
- `src/domain/images/operations.py` — explicit re-export of `NoFilmSimulationError`
- `src/domain/images/queries.py` — `Mapping`/`Sequence` inputs; `re.Match[str]`
- `src/domain/images/recipe_values.py` — `str(wb.value)` to narrow `StrEnum.value` from `Any`
- `src/domain/images/thumbnails/operations.py` — introduced `image: PILImage.Image` to avoid `ImageFile`/`Image` conflict
- `src/domain/recipes/queries.py` — `TYPE_CHECKING` guard for `datetime`; explicit annotations; `_sort_key` return type
- `src/application/usecases/images/compare_recipes.py` — converted 4 re-exports to `X as X` pattern
- `src/interfaces/apps.py` — `-> None` on `ready()`
- `src/interfaces/tasks.py` — positional-only `self: Any, /` for Celery bound tasks
- `src/interfaces/views.py` — full annotation pass; `HttpResponseBase` return where `FileResponse` is returned
- `src/interfaces/templatetags/image_filters.py` — annotated `stars` and `signed` filter functions
- `src/interfaces/management/commands/` — `CommandParser` + `Any` imports; annotated `add_arguments`/`handle` across all 6 commands

**CI**
- `.github/workflows/types.yml` — new workflow running mypy on push/PR to `main`
