### PR TITLE
Fix docstrings to use newline-delimited format

### DIFF
--- a/src/application/usecases/camera/get_camera_info.py
+++ b/src/application/usecases/camera/get_camera_info.py
@@ -13,7 +13,8 @@ class CameraStatusResult:
 
 
 def get_camera_status(*, read_slots: bool) -> CameraStatusResult:
-    """Connect to the camera, read its identity, and optionally read slot states.
+    """
+    Connect to the camera, read its identity, and optionally read slot states.
 
     Manages the full device lifecycle: connect → read → disconnect.
 

--- a/src/application/usecases/camera/get_camera_slots.py
+++ b/src/application/usecases/camera/get_camera_slots.py
@@ -90,10 +90,14 @@ def _set_cursor_with_retry(device: ptp_device.PTPDevice, slot_index: int) -> Non
 
 
 def _read_str_with_retry(device: ptp_device.PTPDevice, code: int) -> str:
-    """Read a string property, retrying on transport failures."""
+    """
+    Read a string property, retrying on transport failures.
+    """
     return _retry(lambda: device.get_property_string(code))
 
 
 def _read_int_with_retry(device: ptp_device.PTPDevice, code: int) -> int:
-    """Read an integer property, retrying on transport failures."""
+    """
+    Read an integer property, retrying on transport failures.
+    """
     return _retry(lambda: device.get_property_int(code))

--- a/src/application/usecases/camera/push_recipe.py
+++ b/src/application/usecases/camera/push_recipe.py
@@ -22,7 +22,9 @@ _CODE_TO_PROP_NAME: dict[int, str] = {
 
 
 class RecipeWriteError(Exception):
-    """Raised when one or more properties could not be written or verified."""
+    """
+    Raised when one or more properties could not be written or verified.
+    """
 
     def __init__(self, failed_properties: list[str]) -> None:
         self.failed_properties = failed_properties

--- a/src/application/usecases/images/generate_thumbnails.py
+++ b/src/application/usecases/images/generate_thumbnails.py
@@ -17,7 +17,8 @@ class ThumbnailGenerationResult:
 
 
 def generate_thumbnails_for_all_images(*, width: int) -> ThumbnailGenerationResult:
-    """Generate or enqueue a thumbnail for every image in the database.
+    """
+    Generate or enqueue a thumbnail for every image in the database.
 
     When USE_ASYNC_TASKS is True, enqueues one Celery task per image.
     When USE_ASYNC_TASKS is False, generates thumbnails synchronously in the calling process.

--- a/src/application/usecases/images/process_images.py
+++ b/src/application/usecases/images/process_images.py
@@ -5,7 +5,8 @@ from src.services import workertasks
 
 
 def import_images_from_folder(*, folder: str) -> int:
-    """Process all JPG images in *folder*, dispatching async or sync based on settings.
+    """
+    Process all JPG images in *folder*, dispatching async or sync based on settings.
 
     Returns the total number of images found.
     """
@@ -16,7 +17,8 @@ def import_images_from_folder(*, folder: str) -> int:
 
 
 def _enqueue_images_in_folder(*, folder: str) -> int:
-    """Enqueue a Celery task for every JPG image found under *folder*.
+    """
+    Enqueue a Celery task for every JPG image found under *folder*.
 
     Returns the total number of tasks enqueued.
     """
@@ -32,7 +34,8 @@ def _enqueue_images_in_folder(*, folder: str) -> int:
 
 
 def _process_images_in_folder(*, folder: str) -> tuple[int, list[str]]:
-    """Process all JPG images in *folder* sequentially, skipping those without Fujifilm metadata.
+    """
+    Process all JPG images in *folder* sequentially, skipping those without Fujifilm metadata.
 
     Returns:
         A tuple of (total_found, skipped_paths).

--- a/src/application/usecases/images/rate_images.py
+++ b/src/application/usecases/images/rate_images.py
@@ -10,7 +10,8 @@ class RateFolderResult:
 
 
 def rate_images_in_folder(*, folder: str, rating: int) -> RateFolderResult:
-    """Rate every Fujifilm image found under *folder* with *rating*.
+    """
+    Rate every Fujifilm image found under *folder* with *rating*.
 
     Returns a result describing which files were rated and which were
     skipped. An IMAGE_RATING_FAILED event is published for each image

--- a/src/application/usecases/recipes/build_graph.py
+++ b/src/application/usecases/recipes/build_graph.py
@@ -12,7 +12,8 @@ class RecipeNetworkResult:
 
 
 def build_recipe_network(*, film_simulation: str) -> RecipeNetworkResult:
-    """Build a spanning tree of recipes for a single film simulation.
+    """
+    Build a spanning tree of recipes for a single film simulation.
 
     The tree is rooted at the most-used recipe for that film simulation (the one
     with the most images; ties broken by lowest pk). All recipes for the film

--- a/src/application/usecases/recipes/create_recipe_card.py
+++ b/src/application/usecases/recipes/create_recipe_card.py
@@ -13,7 +13,8 @@ def create_recipe_card(
     image_id: int | None,
     template: card_templates.CardTemplate,
 ) -> models.RecipeCard:
-    """Create a recipe card for the given recipe and persist it.
+    """
+    Create a recipe card for the given recipe and persist it.
 
     :raises FujifilmRecipe.DoesNotExist: If recipe_id does not exist.
     :raises Image.DoesNotExist: If image_id is given but does not exist.

--- a/src/application/usecases/recipes/create_recipe_manually.py
+++ b/src/application/usecases/recipes/create_recipe_manually.py
@@ -10,21 +10,26 @@ from src.domain.recipes import validation as recipe_validation
 
 @attrs.frozen
 class RecipeAlreadyExistsError(Exception):
-    """Raised when a recipe with the same settings already exists in the database."""
+    """
+    Raised when a recipe with the same settings already exists in the database.
+    """
 
     name: str
 
 
 @attrs.frozen
 class InvalidRecipeDataError(Exception):
-    """Raised when recipe data fails normalization or validation."""
+    """
+    Raised when recipe data fails normalization or validation.
+    """
 
     field: str
     value: object
 
 
 def create_recipe_manually(*, data: image_dataclasses.FujifilmRecipeData) -> models.FujifilmRecipe:
-    """Create a new recipe from manually entered data.
+    """
+    Create a new recipe from manually entered data.
 
     :raises InvalidRecipeDataError: If the data fails normalization or validation.
     :raises RecipeAlreadyExistsError: If a recipe with the same settings already exists.

--- a/src/application/usecases/recipes/fix_empty_grain_recipes.py
+++ b/src/application/usecases/recipes/fix_empty_grain_recipes.py
@@ -10,7 +10,8 @@ class FixResult:
 
 
 def fix_empty_grain_recipes() -> FixResult:
-    """Fix FujifilmRecipe rows where grain_roughness is 'Off' but grain_size is ''.
+    """
+    Fix FujifilmRecipe rows where grain_roughness is 'Off' but grain_size is ''.
 
     Two cases are handled:
 

--- a/src/application/usecases/recipes/import_recipes_from_uploaded_files.py
+++ b/src/application/usecases/recipes/import_recipes_from_uploaded_files.py
@@ -10,7 +10,8 @@ from src.domain.recipes import operations
 def import_recipes_from_uploaded_files(
     *, files: list[recipe_dataclasses.UploadedFile]
 ) -> recipe_dataclasses.ImportRecipesResult:
-    """Extract a models.FujifilmRecipe from each uploaded file's EXIF data.
+    """
+    Extract a models.FujifilmRecipe from each uploaded file's EXIF data.
 
     For each file the bytes are written to a temporary file under /tmp/,
     the recipe is extracted, and the temporary file is deleted immediately

--- a/src/application/usecases/recipes/import_recipes_from_uploaded_qr_cards.py
+++ b/src/application/usecases/recipes/import_recipes_from_uploaded_qr_cards.py
@@ -14,7 +14,8 @@ from src.domain.recipes.cards.queries import (
 def import_recipes_from_uploaded_qr_cards(
     *, files: list[recipe_dataclasses.UploadedFile]
 ) -> recipe_dataclasses.ImportRecipesResult:
-    """Extract a FujifilmRecipe from the QR code on each uploaded card image.
+    """
+    Extract a FujifilmRecipe from the QR code on each uploaded card image.
 
     For each file the bytes are written to a temporary file under /tmp/, the
     QR code is decoded and the recipe extracted, and the temporary file is

--- a/src/application/usecases/recipes/normalize_recipe_rows.py
+++ b/src/application/usecases/recipes/normalize_recipe_rows.py
@@ -42,7 +42,9 @@ def _decimal_str(value: object) -> str | None:
 
 
 def _recipe_data_raw(recipe: models.FujifilmRecipe) -> image_dataclasses.FujifilmRecipeData:
-    """Build FujifilmRecipeData from DB columns without applying normalization."""
+    """
+    Build FujifilmRecipeData from DB columns without applying normalization.
+    """
     return image_dataclasses.FujifilmRecipeData(
         name=recipe.name,
         film_simulation=recipe.film_simulation,
@@ -82,7 +84,8 @@ _NORMALIZABLE_FIELDS: tuple[str, ...] = tuple(_INAPPLICABLE_DB_VALUE)
 
 
 def normalize_recipe_rows() -> NormalizeRecipesResult:
-    """Normalize FujifilmRecipe rows whose inapplicable fields are set to non-null/non-empty values.
+    """
+    Normalize FujifilmRecipe rows whose inapplicable fields are set to non-null/non-empty values.
 
     For each row:
     - Fields that are inapplicable for the row's film sim, DRP state, or grain state

--- a/src/application/usecases/recipes/preview_recipe_card.py
+++ b/src/application/usecases/recipes/preview_recipe_card.py
@@ -13,7 +13,8 @@ def preview_recipe_card(
     image_id: int | None,
     template: card_templates.CardTemplate,
 ) -> Path:
-    """Generate a recipe card preview in /tmp/ and return its path.
+    """
+    Generate a recipe card preview in /tmp/ and return its path.
 
     The output path is deterministic from the arguments, so repeated calls with
     the same options overwrite the previous file rather than accumulating.

--- a/src/domain/camera/device_config.py
+++ b/src/domain/camera/device_config.py
@@ -14,7 +14,9 @@ from src.domain.camera import ptp_device
 
 
 def get_device() -> ptp_device.PTPDevice:
-    """Return a fresh, unconnected PTP device as configured in settings.PTP_DEVICE."""
+    """
+    Return a fresh, unconnected PTP device as configured in settings.PTP_DEVICE.
+    """
     factory = django_settings.PTP_DEVICE
     if isinstance(factory, str):
         module_path, cls_name = factory.rsplit(".", 1)

--- a/src/domain/camera/events.py
+++ b/src/domain/camera/events.py
@@ -11,5 +11,7 @@ PTP_READ_SUCCEEDED = "camera.ptp_read.succeeded"
 
 
 def publish_event(*, event_type: str, **kwargs: object) -> None:
-    """Publish a structured camera event."""
+    """
+    Publish a structured camera event.
+    """
     logger.info(event_type, event_type=event_type, **kwargs)

--- a/src/domain/camera/operations.py
+++ b/src/domain/camera/operations.py
@@ -91,7 +91,8 @@ def verify_written_properties(
     device: ptp_device.PTPDevice,
     written: list[tuple[int, str | int]],
 ) -> list[int]:
-    """Read back each successfully written property and check its value.
+    """
+    Read back each successfully written property and check its value.
 
     Returns a list of PTP codes where the read-back value did not match.
     """

--- a/src/domain/camera/ptp_device.py
+++ b/src/domain/camera/ptp_device.py
@@ -13,15 +13,21 @@ from typing import Protocol, runtime_checkable
 
 
 class CameraConnectionError(Exception):
-    """Raised when the camera is not reachable or the connection fails."""
+    """
+    Raised when the camera is not reachable or the connection fails.
+    """
 
 
 class CameraBusyError(Exception):
-    """Raised when the camera returns a 'busy' status (-5 in libujxp terms)."""
+    """
+    Raised when the camera returns a 'busy' status (-5 in libujxp terms).
+    """
 
 
 class CameraWriteError(Exception):
-    """Raised when the camera actively rejects a property write (non-zero rc)."""
+    """
+    Raised when the camera actively rejects a property write (non-zero rc).
+    """
 
     def __init__(self, code: int, value: str | int, rc: int) -> None:
         self.code = code
@@ -55,7 +61,9 @@ class PTPDevice(Protocol):
         ...
 
     def disconnect(self) -> None:
-        """Close the PTP session and release USB resources."""
+        """
+        Close the PTP session and release USB resources.
+        """
         ...
 
     def ping(self) -> int:

--- a/src/domain/camera/ptp_usb_device.py
+++ b/src/domain/camera/ptp_usb_device.py
@@ -86,20 +86,26 @@ _RETRY_BACKOFF    = _settings.CAMERA_RETRY_BACKOFF_S
 # ---------------------------------------------------------------------------
 
 def _command_packet(code: int, tx_id: int, *params: int) -> bytes:
-    """Build a PTP command container packet (no data payload)."""
+    """
+    Build a PTP command container packet (no data payload).
+    """
     param_bytes = struct.pack(f"<{len(params)}I", *params)
     length = 12 + len(param_bytes)
     return struct.pack("<IHHI", length, _PTP_COMMAND, code, tx_id) + param_bytes
 
 
 def _data_packet(code: int, tx_id: int, payload: bytes) -> bytes:
-    """Build a PTP data container packet."""
+    """
+    Build a PTP data container packet.
+    """
     length = 12 + len(payload)
     return struct.pack("<IHHI", length, _PTP_DATA, code, tx_id) + payload
 
 
 def _parse_response(raw: bytes) -> tuple[int, list[int]]:
-    """Parse a PTP response container. Returns (response_code, [params])."""
+    """
+    Parse a PTP response container. Returns (response_code, [params]).
+    """
     if len(raw) < 12:
         raise ptp_device.CameraConnectionError(
             f"PTP response too short ({len(raw)} bytes); camera may have disconnected."
@@ -116,7 +122,9 @@ def _parse_response(raw: bytes) -> tuple[int, list[int]]:
 # ---------------------------------------------------------------------------
 
 def _decode_ptp_string(data: bytes, offset: int) -> tuple[str, int]:
-    """Decode a PTP string starting at *offset*. Returns (string, new_offset)."""
+    """
+    Decode a PTP string starting at *offset*. Returns (string, new_offset).
+    """
     if offset >= len(data):
         return "", offset
     num_chars = data[offset]
@@ -130,7 +138,9 @@ def _decode_ptp_string(data: bytes, offset: int) -> tuple[str, int]:
 
 
 def _encode_ptp_string(s: str) -> bytes:
-    """Encode a Python string as a PTP string (includes NUL terminator char)."""
+    """
+    Encode a Python string as a PTP string (includes NUL terminator char).
+    """
     if not s:
         return b"\x00"  # numChars = 0
     chars = [ord(c) for c in s] + [0]  # NUL terminated
@@ -139,13 +149,17 @@ def _encode_ptp_string(s: str) -> bytes:
 
 
 def _skip_ptp_string(data: bytes, offset: int) -> int:
-    """Skip a PTP string and return the new offset."""
+    """
+    Skip a PTP string and return the new offset.
+    """
     _, offset = _decode_ptp_string(data, offset)
     return offset
 
 
 def _skip_ptp_uint16_array(data: bytes, offset: int) -> int:
-    """Skip a PTP uint16 array (uint32 count + count × uint16)."""
+    """
+    Skip a PTP uint16 array (uint32 count + count × uint16).
+    """
     if offset + 4 > len(data):
         return offset
     count: int = struct.unpack_from("<I", data, offset)[0]
@@ -190,7 +204,9 @@ def _device_info_offsets(data: bytes) -> tuple[int, int]:
 
 
 def _parse_device_info_model(data: bytes) -> str:
-    """Extract the Model string from a PTP GetDeviceInfo response payload."""
+    """
+    Extract the Model string from a PTP GetDeviceInfo response payload.
+    """
     _, mfr_off = _device_info_offsets(data)
     off = _skip_ptp_string(data, mfr_off)   # Manufacturer
     model, _ = _decode_ptp_string(data, off)
@@ -198,7 +214,9 @@ def _parse_device_info_model(data: bytes) -> str:
 
 
 def _parse_device_info_supported_props(data: bytes) -> list[int]:
-    """Extract DevicePropertiesSupported codes from a PTP GetDeviceInfo response payload."""
+    """
+    Extract DevicePropertiesSupported codes from a PTP GetDeviceInfo response payload.
+    """
     props_off, _ = _device_info_offsets(data)
     if props_off + 4 > len(data):
         return []
@@ -297,7 +315,9 @@ class PTPUSBDevice:
         self._dev = None
 
     def ping(self) -> int:
-        """Read 0xD023 (GrainEffect / ping register). Returns 0 if alive."""
+        """
+        Read 0xD023 (GrainEffect / ping register). Returns 0 if alive.
+        """
         from src.data.camera.constants import PROP_PING
         try:
             self.get_property_int(PROP_PING)
@@ -359,17 +379,23 @@ class PTPUSBDevice:
         return value
 
     def set_property_int(self, code: int, value: int) -> int:
-        """Write a 32-bit signed integer property."""
+        """
+        Write a 32-bit signed integer property.
+        """
         payload = struct.pack("<i", value)
         return self._set_prop(code, payload)
 
     def set_property_uint16(self, code: int, value: int) -> int:
-        """Write a uint16 property."""
+        """
+        Write a uint16 property.
+        """
         payload = struct.pack("<H", value & 0xFFFF)
         return self._set_prop(code, payload)
 
     def set_property_string(self, code: int, value: str) -> int:
-        """Write a PTP string property (used for slot name, 0xD18D)."""
+        """
+        Write a PTP string property (used for slot name, 0xD18D).
+        """
         payload = _encode_ptp_string(value)
         return self._set_prop(code, payload)
 
@@ -399,7 +425,9 @@ class PTPUSBDevice:
     # ------------------------------------------------------------------
 
     def _get_prop_with_retry(self, code: int) -> bytes:
-        """Send GetDevicePropValue and return the raw data, retrying on USB timeout."""
+        """
+        Send GetDevicePropValue and return the raw data, retrying on USB timeout.
+        """
         last_err: ptp_device.CameraConnectionError = ptp_device.CameraConnectionError("No retries attempted")
         for attempt in range(_PROP_MAX_RETRIES):
             if attempt > 0:
@@ -428,7 +456,9 @@ class PTPUSBDevice:
             raise ptp_device.CameraConnectionError(f"USB write failed: {e}") from e
 
     def _recv_data(self) -> bytes:
-        """Receive a data container from the camera (may be empty)."""
+        """
+        Receive a data container from the camera (may be empty).
+        """
         assert self._ep_in is not None
         try:
             raw = bytes(self._ep_in.read(_READ_BUFFER, timeout=_USB_TIMEOUT_MS))
@@ -538,7 +568,9 @@ class PTPUSBDevice:
             )
 
     def _fetch_camera_name(self) -> str:
-        """Read camera model via PTP GetDeviceInfo."""
+        """
+        Read camera model via PTP GetDeviceInfo.
+        """
         try:
             tx = self._next_tx()
             self._send(_command_packet(_OC_GET_DEVICE_INFO, tx))

--- a/src/domain/camera/queries.py
+++ b/src/domain/camera/queries.py
@@ -49,7 +49,9 @@ _DR_PRIORITY_TO_PTP: dict[str, int] = {v: k for k, v in constants.CUSTOM_SLOT_DR
 
 
 def _get_int(device: ptp_device.PTPDevice, code: int) -> int:
-    """Read a 32-bit int property, publishing a read event on success or failure."""
+    """
+    Read a 32-bit int property, publishing a read event on success or failure.
+    """
     try:
         value = device.get_property_int(code)
         events.publish_event(
@@ -66,7 +68,9 @@ def _get_int(device: ptp_device.PTPDevice, code: int) -> int:
 
 
 def _get_int16(device: ptp_device.PTPDevice, code: int) -> int:
-    """Read an int16 property, publishing a read event on success or failure."""
+    """
+    Read an int16 property, publishing a read event on success or failure.
+    """
     try:
         value = device.get_property_int16(code)
         events.publish_event(
@@ -83,7 +87,9 @@ def _get_int16(device: ptp_device.PTPDevice, code: int) -> int:
 
 
 def _get_str(device: ptp_device.PTPDevice, code: int) -> str:
-    """Read a string property, publishing a read event on success or failure."""
+    """
+    Read a string property, publishing a read event on success or failure.
+    """
     try:
         value = device.get_property_string(code)
         events.publish_event(
@@ -100,7 +106,8 @@ def _get_str(device: ptp_device.PTPDevice, code: int) -> str:
 
 
 def _signed(v: int | float) -> str:
-    """Format a signed number as a recipe string (e.g. 2 → '+2', -1.5 → '-1.5').
+    """
+    Format a signed number as a recipe string (e.g. 2 → '+2', -1.5 → '-1.5').
 
     Integer values are formatted without a decimal point; half-steps are preserved.
     """
@@ -115,7 +122,9 @@ def _signed(v: int | float) -> str:
 
 @attrs.frozen
 class CameraInfo:
-    """Snapshot of camera identity and status, collected without modifying state."""
+    """
+    Snapshot of camera identity and status, collected without modifying state.
+    """
     camera_name: str
     battery_raw: int       # raw PTP value from PROP_BATTERY
     usb_mode: int          # raw PTP value from 0xD16E (USBMode)
@@ -145,7 +154,9 @@ def camera_info(device: ptp_device.PTPDevice) -> CameraInfo:
 
 @attrs.frozen
 class SlotState:
-    """Current state of one custom C1–Cn slot as read from the camera."""
+    """
+    Current state of one custom C1–Cn slot as read from the camera.
+    """
     index: int       # 1-based slot number
     name: str        # display name stored in the slot
     film_sim_ptp: int  # raw PTP FilmSimulation value (see constants.PTP_TO_FILM_SIMULATION)
@@ -311,7 +322,8 @@ class RecipePTPValues:
     MonochromaticColorMagentaGreen: int | None = None
 
     def items(self) -> list[tuple[int, int]]:
-        """Return (ptp_code, value) pairs for all properties that are set.
+        """
+        Return (ptp_code, value) pairs for all properties that are set.
 
         Write order matters: WhiteBalanceColorTemperature must be written
         before WhiteBalanceRed/WhiteBalanceBlue; otherwise the camera resets

--- a/src/domain/camera/validation.py
+++ b/src/domain/camera/validation.py
@@ -54,7 +54,9 @@ _EMPTY_OR_NA: frozenset[str] = frozenset(("", "N/A"))
 
 
 class RecipeValidationError(ValueError):
-    """Raised when a FujifilmRecipeData field contains a value the camera cannot accept."""
+    """
+    Raised when a FujifilmRecipeData field contains a value the camera cannot accept.
+    """
 
     def __init__(self, field: str, value: object) -> None:
         self.field = field

--- a/src/domain/images/events.py
+++ b/src/domain/images/events.py
@@ -19,5 +19,7 @@ TASK_IMAGE_COMPLETED = "task.image.completed"
 
 
 def publish_event(*, event_type: str, **kwargs: object) -> None:
-    """Publish a structured application event."""
+    """
+    Publish a structured application event.
+    """
     logger.info(event_type, event_type=event_type, **kwargs)

--- a/src/domain/images/filter_queries.py
+++ b/src/domain/images/filter_queries.py
@@ -194,7 +194,9 @@ def get_gallery_data(
     page_number: int | str,
     page_size: int,
 ) -> GalleryData:
-    """Return all data needed to render the gallery page in a single query bundle."""
+    """
+    Return all data needed to render the gallery page in a single query bundle.
+    """
     active_field_filters = {k: v for k, v in active_filters.items() if k != "recipe_id"}
     qs = get_filtered_images(active_filters=active_filters, rating_first=rating_first)
     page_obj = django_paginator.Paginator(qs, page_size).get_page(page_number)

--- a/src/domain/images/operations.py
+++ b/src/domain/images/operations.py
@@ -11,20 +11,25 @@ from src.domain.recipes import operations as recipe_operations
 
 @attrs.frozen
 class InvalidImageRatingError(Exception):
-    """Raised when a rating value is outside the allowed range [0, IMAGE_MAX_RATING]."""
+    """
+    Raised when a rating value is outside the allowed range [0, IMAGE_MAX_RATING].
+    """
 
     rating: int
 
 
 @attrs.frozen
 class UnableToRateImage(Exception):
-    """Raised when an image cannot be rated for any reason."""
+    """
+    Raised when an image cannot be rated for any reason.
+    """
 
     image_path: str
 
 
 def set_image_rating(*, image: models.Image, rating: int) -> None:
-    """Set the rating of *image* to *rating*.
+    """
+    Set the rating of *image* to *rating*.
 
     Raises:
         InvalidImageRatingError: If *rating* is negative or exceeds
@@ -41,7 +46,8 @@ def set_image_rating(*, image: models.Image, rating: int) -> None:
 
 
 def rate_image(*, image_path: str, rating: int) -> models.Image:
-    """Find the Image for *image_path* and set its rating.
+    """
+    Find the Image for *image_path* and set its rating.
 
     Does not create a new DB record if the image is not found.
 
@@ -61,7 +67,8 @@ def rate_image(*, image_path: str, rating: int) -> models.Image:
 
 
 def toggle_image_favorite(*, image_id: int) -> bool:
-    """Toggle the is_favorite flag for the image with the given *image_id*.
+    """
+    Toggle the is_favorite flag for the image with the given *image_id*.
 
     Returns the new value of is_favorite after toggling.
     """
@@ -72,7 +79,8 @@ def toggle_image_favorite(*, image_id: int) -> bool:
 
 
 def process_image(*, image_path: str) -> models.Image:
-    """Read EXIF data from *image_path* and persist it to the database.
+    """
+    Read EXIF data from *image_path* and persist it to the database.
 
     If a record for the same filepath already exists it is updated in-place.
     A FujifilmExif record is looked up or created for the image's EXIF field

--- a/src/domain/images/queries.py
+++ b/src/domain/images/queries.py
@@ -16,16 +16,22 @@ from src.domain.recipes import constants as recipe_constants
 from src.domain.recipes import normalization as recipe_normalization
 
 class ImageNotFound(Exception):
-    """Raised when no DB record matches the given image file."""
+    """
+    Raised when no DB record matches the given image file.
+    """
 
 
 class AmbiguousImageMatch(Exception):
-    """Raised when multiple DB records match the given image file."""
+    """
+    Raised when multiple DB records match the given image file.
+    """
 
 
 @attrs.frozen
 class NoFilmSimulationError(Exception):
-    """Raised when an image has no film simulation in its EXIF data."""
+    """
+    Raised when an image has no film simulation in its EXIF data.
+    """
 
     image_path: str = ""
 
@@ -153,7 +159,9 @@ _GROUP_OVERRIDES = {
 
 
 def parse_exif_date(*, value: str) -> datetime | None:
-    """Parse an exiftool date string into a timezone-aware datetime."""
+    """
+    Parse an exiftool date string into a timezone-aware datetime.
+    """
     m = _EXIF_DATE_RE.match(value.strip())
     if not m:
         return None
@@ -169,14 +177,18 @@ def parse_exif_date(*, value: str) -> datetime | None:
 
 
 def _normalize_wb_fine_tune(*, raw: str) -> str:
-    """Divide exiftool White Balance Fine Tune values by 20 to get camera values."""
+    """
+    Divide exiftool White Balance Fine Tune values by 20 to get camera values.
+    """
     def _divide(m: re.Match[str]) -> str:
         return f"{m.group(1)} {int(m.group(2)) // 20:+d}"
     return _WB_FINE_TUNE_RE.sub(_divide, raw)
 
 
 def read_image_exif(*, image_path: str) -> image_dataclasses.ImageExifData:
-    """Run exiftool on the given image and return a dict of recipe-relevant fields."""
+    """
+    Run exiftool on the given image and return a dict of recipe-relevant fields.
+    """
     result = subprocess.run(
         ["exiftool", "-a", "-G1", image_path],
         capture_output=True,
@@ -217,7 +229,9 @@ def read_image_exif(*, image_path: str) -> image_dataclasses.ImageExifData:
 
 
 def exif_to_recipe(*, exif: image_dataclasses.ImageExifData) -> image_dataclasses.FujifilmRecipeData:
-    """Convert an ImageExifData instance to a FujifilmRecipeData."""
+    """
+    Convert an ImageExifData instance to a FujifilmRecipeData.
+    """
     film_simulation = recipe_values.film_simulation_from_exif(film_simulation=exif.film_simulation, color=exif.color).display_name
     is_mono = film_simulation in recipe_constants.MONOCHROMATIC_FILM_SIMULATIONS
     d_range_priority = recipe_values.d_range_priority_from_exif(d_range_priority=exif.d_range_priority, d_range_priority_auto=exif.d_range_priority_auto)
@@ -287,7 +301,8 @@ _LOOKUP_STRATEGIES = [
 
 
 def find_image_for_path(*, image_path: str) -> models.Image:
-    """Return the DB Image record that corresponds to the given image file.
+    """
+    Return the DB Image record that corresponds to the given image file.
 
     Strategies are tried in order; the first one that returns a unique match
     wins. To add a new strategy, append a function with the signature
@@ -316,7 +331,9 @@ def find_image_for_path(*, image_path: str) -> models.Image:
 
 
 def collect_image_paths(*, folder: str) -> list[str]:
-    """Return absolute paths of all JPG files inside *folder* (recursively)."""
+    """
+    Return absolute paths of all JPG files inside *folder* (recursively).
+    """
     root = Path(folder)
     if not root.is_dir():
         raise FileNotFoundError(f"Directory not found: {folder}")
@@ -345,7 +362,8 @@ def get_image_detail(
     active_filters: Mapping[str, Sequence[str]],
     rating_first: bool,
 ) -> ImageDetailContext:
-    """Fetch an image and its prev/next neighbours within the filtered image sequence.
+    """
+    Fetch an image and its prev/next neighbours within the filtered image sequence.
 
     Raises:
         models.Image.DoesNotExist: If no image with *image_id* exists.
@@ -386,7 +404,8 @@ class RecipeImagePage:
 
 
 def get_recipe_image_page(*, recipe_id: int, image_id: int) -> RecipeImagePage:
-    """Return prev/next image IDs for *image_id* within a recipe's ordered sequence.
+    """
+    Return prev/next image IDs for *image_id* within a recipe's ordered sequence.
 
     Raises:
         models.Image.DoesNotExist: if *image_id* does not belong to *recipe_id*.
@@ -403,7 +422,8 @@ def get_recipe_image_page(*, recipe_id: int, image_id: int) -> RecipeImagePage:
 
 
 def get_images_for_recipe(*, recipe_id: int) -> list[int]:
-    """Return image IDs belonging to a recipe, ordered by rating desc then taken_at desc.
+    """
+    Return image IDs belonging to a recipe, ordered by rating desc then taken_at desc.
 
     Images are ordered so the highest-rated, most-recent images appear first.
     A stable tiebreaker on ``id`` ensures consistent pagination across pages.

--- a/src/domain/images/recipe_values.py
+++ b/src/domain/images/recipe_values.py
@@ -112,7 +112,9 @@ _FILM_SIMULATION_FROM_COLOR: dict[str, FilmSimulation] = {
 
 
 def film_simulation_from_exif(*, film_simulation: str, color: str) -> FilmSimulation:
-    """Resolve the FilmSimulation from the two relevant EXIF fields."""
+    """
+    Resolve the FilmSimulation from the two relevant EXIF fields.
+    """
     if film_simulation:
         return _FILM_SIMULATION_FROM_EXIF[film_simulation]
     return _FILM_SIMULATION_FROM_COLOR[color]
@@ -151,7 +153,8 @@ class DRangePriority(str, Enum):
 
 
 def dynamic_range_from_exif(*, dynamic_range_setting: str, development_dynamic_range: str) -> str:
-    """Return recipe dynamic_range string from EXIF fields.
+    """
+    Return recipe dynamic_range string from EXIF fields.
 
     Returns empty string when dynamic_range_setting is absent (i.e. D-Range Priority is active).
     """
@@ -165,7 +168,9 @@ def dynamic_range_from_exif(*, dynamic_range_setting: str, development_dynamic_r
 
 
 def d_range_priority_from_exif(*, d_range_priority: str, d_range_priority_auto: str) -> DRangePriority:
-    """Resolve D-Range Priority setting from the two relevant EXIF fields."""
+    """
+    Resolve D-Range Priority setting from the two relevant EXIF fields.
+    """
     if d_range_priority == "Auto":
         return DRangePriority.AUTO
     if d_range_priority == "Fixed":
@@ -236,7 +241,9 @@ class WhiteBalanceFineTune:
 
     @classmethod
     def from_string(cls, *, s: str) -> WhiteBalanceFineTune:
-        """Parse a normalised WB fine-tune string, e.g. 'Red +2, Blue -4'."""
+        """
+        Parse a normalised WB fine-tune string, e.g. 'Red +2, Blue -4'.
+        """
         m_red = re.search(r"Red\s+([+-]?\d+)", s)
         m_blue = re.search(r"Blue\s+([+-]?\d+)", s)
         return cls(
@@ -246,7 +253,8 @@ class WhiteBalanceFineTune:
 
 
 def white_balance_from_exif(*, white_balance: str, color_temperature: str) -> str:
-    """Return the WB display string for FujifilmRecipeData.
+    """
+    Return the WB display string for FujifilmRecipeData.
 
     Kelvin mode stores the temperature in a separate field; all other modes
     use their EXIF value directly (e.g. 'Auto', 'Daylight').
@@ -258,7 +266,9 @@ def white_balance_from_exif(*, white_balance: str, color_temperature: str) -> st
 
 
 def white_balance_fine_tune_from_exif(*, white_balance_fine_tune: str) -> tuple[int, int]:
-    """Return (red, blue) fine-tune integers from the normalised EXIF string."""
+    """
+    Return (red, blue) fine-tune integers from the normalised EXIF string.
+    """
     if not white_balance_fine_tune:
         return 0, 0
     ft = WhiteBalanceFineTune.from_string(s=white_balance_fine_tune)
@@ -291,7 +301,9 @@ class DevelopmentDynamicRange(str, Enum):
 
     @property
     def dynamic_range_setting(self) -> str:
-        """Companion 'Dynamic Range Setting' EXIF field value."""
+        """
+        Companion 'Dynamic Range Setting' EXIF field value.
+        """
         return "Auto" if self == DevelopmentDynamicRange.AUTO else "Manual"
 
     @classmethod
@@ -330,7 +342,9 @@ class ColorChromeEffect(str, Enum):
 
 
 def color_chrome_effect_from_exif(*, value: str) -> ColorChromeEffect:
-    """Return ColorChromeEffect from the EXIF 'Color Chrome Effect' field."""
+    """
+    Return ColorChromeEffect from the EXIF 'Color Chrome Effect' field.
+    """
     return ColorChromeEffect(value) if value else ColorChromeEffect.OFF
 
 
@@ -353,7 +367,9 @@ class ColorChromeFxBlue(str, Enum):
 
 
 def color_chrome_fx_blue_from_exif(*, value: str) -> ColorChromeFxBlue:
-    """Return ColorChromeFxBlue from the EXIF 'Color Chrome FX Blue' field."""
+    """
+    Return ColorChromeFxBlue from the EXIF 'Color Chrome FX Blue' field.
+    """
     return ColorChromeFxBlue(value) if value else ColorChromeFxBlue.OFF
 
 
@@ -394,7 +410,9 @@ class GrainEffectSize(str, Enum):
 
 @attrs.define
 class GrainEffect:
-    """Combined grain effect parsed from a recipe card label e.g. 'Strong Large' or 'Off'."""
+    """
+    Combined grain effect parsed from a recipe card label e.g. 'Strong Large' or 'Off'.
+    """
     roughness: GrainEffectRoughness
     size: GrainEffectSize
 
@@ -448,7 +466,9 @@ class HighlightTone(str, Enum):
 
     @classmethod
     def from_recipe_card(cls, *, value: str) -> HighlightTone:
-        """Parse a recipe card numeric string e.g. '-1.0', '+2.0', '0'."""
+        """
+        Parse a recipe card numeric string e.g. '-1.0', '+2.0', '0'.
+        """
         return _HIGHLIGHT_TONE_FROM_NUMERIC[float(value)]
 
 
@@ -476,7 +496,9 @@ class ShadowTone(str, Enum):
 
     @classmethod
     def from_recipe_card(cls, *, value: str) -> ShadowTone:
-        """Parse a recipe card numeric string e.g. '+1.0', '-2.0', '0'."""
+        """
+        Parse a recipe card numeric string e.g. '+1.0', '-2.0', '0'.
+        """
         return _SHADOW_TONE_FROM_NUMERIC[float(value)]
 
 
@@ -517,7 +539,9 @@ _TONE_NUMERIC.update({v: k for k, v in _SHADOW_TONE_MAP.items()})
 
 
 def _tone_str(*, n: float) -> str:
-    """Format a tone numeric value as a signed string, e.g. '+1.5', '-0.5', '0'."""
+    """
+    Format a tone numeric value as a signed string, e.g. '+1.5', '-0.5', '0'.
+    """
     if n == 0.0:
         return "0"
     formatted = f"{n:+.1f}".rstrip("0").rstrip(".")
@@ -525,12 +549,16 @@ def _tone_str(*, n: float) -> str:
 
 
 def highlight_from_exif(*, highlight_tone: str) -> str:
-    """Return the highlight tone as a signed string, e.g. '+1.5', '-2', '0'."""
+    """
+    Return the highlight tone as a signed string, e.g. '+1.5', '-2', '0'.
+    """
     return _tone_str(n=HighlightTone(highlight_tone).numeric)
 
 
 def shadow_from_exif(*, shadow_tone: str) -> str:
-    """Return the shadow tone as a signed string, e.g. '+3', '-0.5', '0'."""
+    """
+    Return the shadow tone as a signed string, e.g. '+3', '-0.5', '0'.
+    """
     return _tone_str(n=ShadowTone(shadow_tone).numeric)
 
 
@@ -593,7 +621,8 @@ _NON_NUMERIC_COLOR_VALUES: frozenset[str] = frozenset({
 
 
 def color_from_exif(*, color: str) -> str | None:
-    """Return the numeric color/saturation value as a signed string, or None.
+    """
+    Return the numeric color/saturation value as a signed string, or None.
 
     Positive values are prefixed with '+' (e.g. '+2'), negative with '-'
     (e.g. '-3'), zero is '0'.
@@ -645,7 +674,8 @@ _NUMERIC_SHARPNESS_VALUES: frozenset[str] = frozenset(s.value for s in Sharpness
 
 
 def sharpness_from_exif(*, sharpness: str) -> str:
-    """Return the numeric sharpness value as a signed string, or 'N/A'.
+    """
+    Return the numeric sharpness value as a signed string, or 'N/A'.
 
     'Film Simulation' appears on some bodies where sharpness is controlled by
     the film simulation; there is no user-set numeric value in that case.
@@ -657,7 +687,9 @@ def sharpness_from_exif(*, sharpness: str) -> str:
 
 
 class NoiseReduction(str, Enum):
-    """Recipe cards label this field 'ISO Denoise'."""
+    """
+    Recipe cards label this field 'ISO Denoise'.
+    """
     MINUS_4 = "-4 (weakest)"
     MINUS_3 = "-3 (very weak)"
     MINUS_2 = "-2 (weak)"
@@ -695,7 +727,8 @@ _NOISE_REDUCTION_LEGACY: dict[str, int] = {"Normal": 0}
 
 
 def noise_reduction_from_exif(*, noise_reduction: str) -> str:
-    """Return the numeric noise reduction value as a signed string.
+    """
+    Return the numeric noise reduction value as a signed string.
 
     Handles the legacy 'Normal' label from older firmware as 0.
     """
@@ -712,7 +745,9 @@ def noise_reduction_from_exif(*, noise_reduction: str) -> str:
 # ---------------------------------------------------------------------------
 
 def clarity_from_exif(*, clarity: str) -> str:
-    """Return the numeric clarity value as a signed string, e.g. '+3', '-4', '0'."""
+    """
+    Return the numeric clarity value as a signed string, e.g. '+3', '-4', '0'.
+    """
     n = int(clarity)
     return f"+{n}" if n > 0 else str(n)
 
@@ -724,7 +759,8 @@ def clarity_from_exif(*, clarity: str) -> str:
 # ---------------------------------------------------------------------------
 
 def monochromatic_color_from_exif(*, value: str) -> str | None:
-    """Return the monochromatic tuning value as a signed string, or None.
+    """
+    Return the monochromatic tuning value as a signed string, or None.
 
     None indicates a colour film simulation where this setting is not available.
     """

--- a/src/domain/images/thumbnails/operations.py
+++ b/src/domain/images/thumbnails/operations.py
@@ -19,9 +19,11 @@ _ORIENTATION_TO_TRANSPOSE = {
 
 
 def generate_thumbnail(*, original_path: Path, width: int) -> Path:
-    """Resize *original_path* to *width* px wide, applying EXIF orientation, and
+    """
+    Resize *original_path* to *width* px wide, applying EXIF orientation, and
     save to the thumbnail cache.  Returns the cache path.  Skips generation if
-    a cached file already exists."""
+    a cached file already exists.
+    """
     cache_path = thumbnail_queries.thumbnail_cache_path(original_path=original_path, width=width)
     if cache_path.is_file():
         return cache_path
@@ -61,6 +63,8 @@ def generate_thumbnail(*, original_path: Path, width: int) -> Path:
 
 
 def generate_thumbnail_with_content_type(*, original_path: Path, width: int) -> tuple[Path, str]:
-    """Generate a thumbnail and return ``(cache_path, content_type)`` in one call."""
+    """
+    Generate a thumbnail and return ``(cache_path, content_type)`` in one call.
+    """
     cache_path = generate_thumbnail(original_path=original_path, width=width)
     return cache_path, thumbnail_queries.thumbnail_content_type(cache_path=cache_path)

--- a/src/domain/images/thumbnails/queries.py
+++ b/src/domain/images/thumbnails/queries.py
@@ -6,12 +6,16 @@ from django.conf import settings
 
 
 def thumbnail_cache_path(*, original_path: Path, width: int) -> Path:
-    """Return the cache file path for a thumbnail of *original_path* at *width* px."""
+    """
+    Return the cache file path for a thumbnail of *original_path* at *width* px.
+    """
     key = hashlib.md5(f"{original_path}:{width}".encode()).hexdigest()
     return Path(settings.THUMBNAIL_CACHE_DIR) / f"{key}{original_path.suffix}"
 
 
 def thumbnail_content_type(*, cache_path: Path) -> str:
-    """Return the MIME type for *cache_path*, defaulting to ``image/jpeg``."""
+    """
+    Return the MIME type for *cache_path*, defaulting to ``image/jpeg``.
+    """
     content_type, _ = mimetypes.guess_type(cache_path.name)
     return content_type or "image/jpeg"

--- a/src/domain/recipes/cards/dataclasses.py
+++ b/src/domain/recipes/cards/dataclasses.py
@@ -5,7 +5,8 @@ import attrs
 
 @attrs.frozen
 class QRFujifilmRecipe:
-    """Parsed recipe payload decoded from a recipe-card QR code.
+    """
+    Parsed recipe payload decoded from a recipe-card QR code.
 
     Mirrors the JSON payload produced by
     :func:`src.domain.recipes.cards.queries.get_recipe_as_json`. Field names

--- a/src/domain/recipes/cards/operations.py
+++ b/src/domain/recipes/cards/operations.py
@@ -36,7 +36,9 @@ _GRADIENT_BOTTOM = (30, 20, 70)
 
 
 def _cover_fill(img: PILImage.Image, target_w: int, target_h: int) -> PILImage.Image:
-    """Scale *img* so it fills (target_w × target_h) with no empty space, then center-crop."""
+    """
+    Scale *img* so it fills (target_w × target_h) with no empty space, then center-crop.
+    """
     scale = max(target_w / img.width, target_h / img.height)
     new_w = int(img.width * scale)
     new_h = int(img.height * scale)
@@ -47,7 +49,9 @@ def _cover_fill(img: PILImage.Image, target_w: int, target_h: int) -> PILImage.I
 
 
 def _build_gradient(width: int, height: int) -> PILImage.Image:
-    """Return a soft vertical gradient from _GRADIENT_TOP to _GRADIENT_BOTTOM."""
+    """
+    Return a soft vertical gradient from _GRADIENT_TOP to _GRADIENT_BOTTOM.
+    """
     img = PILImage.new("RGB", (width, height))
     draw = ImageDraw.Draw(img)
     r0, g0, b0 = _GRADIENT_TOP
@@ -71,7 +75,9 @@ def _load_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
 
 
 def _embed_recipe_exif(*, filepath: Path, json_str: str) -> None:
-    """Embed recipe JSON into the UserComment EXIF field of the saved JPEG at filepath."""
+    """
+    Embed recipe JSON into the UserComment EXIF field of the saved JPEG at filepath.
+    """
     exif_bytes = piexif.dump({
         "Exif": {
             piexif.ExifIFD.UserComment: b"ASCII\x00\x00\x00" + json_str.encode("ascii"),
@@ -86,7 +92,9 @@ def _compose_card(
     template: card_templates.CardTemplate,
     background_image: models.Image | None,
 ) -> tuple[PILImage.Image, str, bool]:
-    """Build the card PIL image. Returns (canvas, json_str, use_gradient)."""
+    """
+    Build the card PIL image. Returns (canvas, json_str, use_gradient).
+    """
     target_w, target_h = template.output_size
     if background_image is None:
         canvas = _build_gradient(target_w, target_h)
@@ -164,7 +172,8 @@ def preview_recipe_card_image(
     background_image: models.Image | None,
     output_path: Path,
 ) -> Path:
-    """Compose a recipe card image and save it to output_path. Return output_path.
+    """
+    Compose a recipe card image and save it to output_path. Return output_path.
 
     Intended for previews: the caller controls the exact output path (e.g. a
     deterministic /tmp/ path) so successive previews for the same options
@@ -184,7 +193,8 @@ def create_recipe_card_image(
     background_image: models.Image | None,
     output_dir: Path,
 ) -> Path:
-    """Compose a recipe card image and save it to output_dir. Return the file path.
+    """
+    Compose a recipe card image and save it to output_dir. Return the file path.
 
     If background_image is given, resizes/crops it to template.output_size and
     applies Gaussian blur when template.background_effect == "blur".
@@ -206,7 +216,8 @@ def create_recipe_card(
     background_image: models.Image | None,
     output_dir: Path,
 ) -> models.RecipeCard:
-    """Create a recipe card image, persist a RecipeCard record, and publish an event.
+    """
+    Create a recipe card image, persist a RecipeCard record, and publish an event.
 
     Calls create_recipe_card_image internally, then saves a RecipeCard to the DB
     and publishes a recipe.card.created event.

--- a/src/domain/recipes/cards/queries.py
+++ b/src/domain/recipes/cards/queries.py
@@ -121,7 +121,9 @@ _DRP_CONTROLLED_FIELDS: frozenset[str] = frozenset({
 
 
 def _is_applicable(recipe: models.FujifilmRecipe, field: str) -> bool:
-    """Return False when a field is semantically inapplicable for this recipe."""
+    """
+    Return False when a field is semantically inapplicable for this recipe.
+    """
     is_monochromatic = recipe.film_simulation in recipe_constants.MONOCHROMATIC_FILM_SIMULATIONS
     drp_active = recipe.d_range_priority != "Off"
     if field in _COLOR_ONLY_FIELDS and is_monochromatic:
@@ -136,7 +138,8 @@ def _is_applicable(recipe: models.FujifilmRecipe, field: str) -> bool:
 
 
 def get_recipe_as_json(*, recipe: models.FujifilmRecipe) -> str:
-    """Return a minified JSON string encoding the recipe (used as QR payload).
+    """
+    Return a minified JSON string encoding the recipe (used as QR payload).
 
     Uses short snake_case keys. Fields that are None and semantically inapplicable
     for the current film simulation are omitted. Values of 0 or other defaults are
@@ -164,7 +167,8 @@ def get_recipe_cover_lines(
     recipe: models.FujifilmRecipe,
     template: card_templates.CardTemplate,
 ) -> tuple[FieldLine, ...]:
-    """Return display lines for the recipe card formatted per template label style.
+    """
+    Return display lines for the recipe card formatted per template label style.
 
     Inapplicable fields (same rules as get_recipe_as_json) and null values are omitted.
     """
@@ -183,14 +187,17 @@ def get_recipe_cover_lines(
 
 @attrs.frozen
 class QRCodeNotFoundError(Exception):
-    """No decodable QR code was found in the image."""
+    """
+    No decodable QR code was found in the image.
+    """
 
     image_path: str = ""
 
 
 @attrs.frozen
 class InvalidQRRecipePayloadError(Exception):
-    """QR decoded but the content is not a valid QRFujifilmRecipe payload.
+    """
+    QR decoded but the content is not a valid QRFujifilmRecipe payload.
 
     ``reason`` is one of:
       - ``"invalid_json"`` — decoded string is not valid JSON.
@@ -237,7 +244,8 @@ _QR_KNOWN_KEYS: frozenset[str] = (
 
 
 def _check_payload_types(payload: dict[str, object], *, image_path: str) -> None:
-    """Raise InvalidQRRecipePayloadError if any present field has the wrong type.
+    """
+    Raise InvalidQRRecipePayloadError if any present field has the wrong type.
 
     ``bool`` is explicitly rejected for int/decimal fields because Python treats
     ``bool`` as a subclass of ``int``, which would otherwise let ``true``/``false``
@@ -270,7 +278,9 @@ def _decode_qr(*, image_path: str) -> str:
 
 
 def _read_exif_recipe(*, image_path: str) -> str:
-    """Read the recipe JSON embedded in the EXIF UserComment field, or return an empty string."""
+    """
+    Read the recipe JSON embedded in the EXIF UserComment field, or return an empty string.
+    """
     try:
         exif = piexif.load(image_path)
     except Exception:  # noqa: BLE001 — piexif raises bare Exception on malformed files
@@ -282,7 +292,8 @@ def _read_exif_recipe(*, image_path: str) -> str:
 
 
 def get_qr_recipe_from_image(*, image_path: str) -> card_dataclasses.QRFujifilmRecipe:
-    """Decode the QR code embedded in a recipe-card image into a QRFujifilmRecipe.
+    """
+    Decode the QR code embedded in a recipe-card image into a QRFujifilmRecipe.
 
     :raises QRCodeNotFoundError: If the file cannot be opened as an image or no
         QR code can be decoded from it.
@@ -328,7 +339,8 @@ def _signed_decimal_or_none(value: int | float | None) -> str | None:
 def get_recipe_data_from_qr_recipe(
     *, qr_recipe: card_dataclasses.QRFujifilmRecipe,
 ) -> image_dataclasses.FujifilmRecipeData:
-    """Translate a decoded QRFujifilmRecipe into a FujifilmRecipeData.
+    """
+    Translate a decoded QRFujifilmRecipe into a FujifilmRecipeData.
 
     Inverts the formatting decisions made by get_recipe_as_json and fills in
     canonical defaults for fields that the QR payload omits:

--- a/src/domain/recipes/dataclasses.py
+++ b/src/domain/recipes/dataclasses.py
@@ -7,7 +7,9 @@ from src.data import models
 
 @attrs.frozen
 class UploadedFile:
-    """Carries the raw bytes of an uploaded image together with its original filename."""
+    """
+    Carries the raw bytes of an uploaded image together with its original filename.
+    """
 
     name: str
     content: bytes

--- a/src/domain/recipes/graph.py
+++ b/src/domain/recipes/graph.py
@@ -33,7 +33,9 @@ def hamming_distance(
     a: models.FujifilmRecipe,
     b: models.FujifilmRecipe,
 ) -> int:
-    """Return the number of recipe fields that differ between *a* and *b*."""
+    """
+    Return the number of recipe fields that differ between *a* and *b*.
+    """
     return sum(
         1 for field in _RECIPE_GRAPH_FIELDS
         if getattr(a, field) != getattr(b, field)
@@ -104,7 +106,8 @@ def build_film_sim_tree(
     all_recipes: list[models.FujifilmRecipe],
     image_counts: dict[int, int],
 ) -> FilmSimTreeData:
-    """Build a shortest-path spanning tree rooted at *root*.
+    """
+    Build a shortest-path spanning tree rooted at *root*.
 
     Each node is connected to a parent such that the sum of edge distances along
     the path from root to that node equals hamming_distance(root, node). This means
@@ -189,7 +192,8 @@ def build_all_recipe_graph(
     all_recipes: list[models.FujifilmRecipe],
     image_counts: dict[int, int],
 ) -> AllRecipeGraphData:
-    """Build a per-film-simulation recipe network.
+    """
+    Build a per-film-simulation recipe network.
 
     Recipes are only connected to other recipes sharing the same film simulation,
     producing one island per film sim. Within each island, edges are drawn for pairs
@@ -229,8 +233,10 @@ def build_all_recipe_graph(
                 distances_present[pk_j].add(d)
 
     def _blocked(pk: int, d: int) -> bool:
-        """A node is blocked from distance-d edges if it already has neighbours at
-        both d-1 and d-2. Distances 1 and 2 are never blocked (d-2 <= 0 never exists)."""
+        """
+        A node is blocked from distance-d edges if it already has neighbours at
+        both d-1 and d-2. Distances 1 and 2 are never blocked (d-2 <= 0 never exists).
+        """
         present = distances_present[pk]
         return (d - 1) in present and (d - 2) in present
 
@@ -250,7 +256,8 @@ def build_recipe_graph(
     max_distance: int,
     image_counts: dict[int, int],
 ) -> RecipeGraphData:
-    """Build a recipe graph centred on *root*.
+    """
+    Build a recipe graph centred on *root*.
 
     Nodes: all recipes (including root) whose Hamming distance from *root* is
     strictly less than *max_distance*.

--- a/src/domain/recipes/normalization.py
+++ b/src/domain/recipes/normalization.py
@@ -9,7 +9,8 @@ from src.domain.recipes import constants as recipe_constants
 def normalize_recipe_data(
     data: image_dataclasses.FujifilmRecipeData,
 ) -> image_dataclasses.FujifilmRecipeData:
-    """Return a copy of *data* with inapplicable fields set to None.
+    """
+    Return a copy of *data* with inapplicable fields set to None.
 
     Applies the applicability rules defined in ADR 007:
     - Mono sim  → color = None; mono color fields preserved.

--- a/src/domain/recipes/operations.py
+++ b/src/domain/recipes/operations.py
@@ -13,7 +13,8 @@ from src.domain.recipes.cards import queries as card_queries
 
 
 def _parse_numeric(*, s: str | None) -> Decimal | None:
-    """Convert a signed numeric string like '+4', '-1.5', '0' to Decimal, or None.
+    """
+    Convert a signed numeric string like '+4', '-1.5', '0' to Decimal, or None.
 
     Decimal is used (not float or int) so that half-step values like -1.5 and
     +0.5 are stored exactly in the DecimalField without rounding.
@@ -25,8 +26,10 @@ def _parse_numeric(*, s: str | None) -> Decimal | None:
 
 def get_or_create_recipe_from_data(
     *, data: image_dataclasses.FujifilmRecipeData,
+
 ) -> tuple[models.FujifilmRecipe, bool]:
-    """Create or retrieve a FujifilmRecipe for the given recipe data.
+    """
+    Create or retrieve a FujifilmRecipe for the given recipe data.
 
     Returns ``(recipe, created)``. Uniqueness is determined by the recipe
     settings only — ``data.name`` is applied via ``defaults`` on the create
@@ -77,7 +80,8 @@ def get_or_create_recipe_from_data(
 def get_or_create_recipe_from_metadata(
     *, metadata: image_dataclasses.ImageExifData,
 ) -> tuple[models.FujifilmRecipe, bool]:
-    """Create or retrieve a FujifilmRecipe for the given parsed EXIF data.
+    """
+    Create or retrieve a FujifilmRecipe for the given parsed EXIF data.
 
     :raises NoFilmSimulationError: If the EXIF data contains no known film simulation.
     """
@@ -91,7 +95,8 @@ def get_or_create_recipe_from_metadata(
 def get_or_create_recipe_from_filepath(
     *, filepath: str,
 ) -> tuple[models.FujifilmRecipe, bool]:
-    """Read EXIF from *filepath* and return the matching FujifilmRecipe, creating it if needed.
+    """
+    Read EXIF from *filepath* and return the matching FujifilmRecipe, creating it if needed.
 
     :raises NoFilmSimulationError: If the file is not a Fujifilm image or has no film simulation.
     """
@@ -104,7 +109,8 @@ def get_or_create_recipe_from_filepath(
 def get_or_create_recipe_from_qr_card(
     *, filepath: str,
 ) -> tuple[models.FujifilmRecipe, bool]:
-    """Decode the QR on a recipe-card image and return the matching FujifilmRecipe.
+    """
+    Decode the QR on a recipe-card image and return the matching FujifilmRecipe.
 
     :raises QRCodeNotFoundError: If no QR code can be decoded from *filepath*.
     :raises InvalidQRRecipePayloadError: If the decoded content is not a valid
@@ -117,28 +123,35 @@ def get_or_create_recipe_from_qr_card(
 
 @attrs.frozen
 class RecipeNotFoundError(Exception):
-    """Raised when no recipe with the given ID exists."""
+    """
+    Raised when no recipe with the given ID exists.
+    """
 
     recipe_id: int
 
 
 @attrs.frozen
 class ImageNotFoundError(Exception):
-    """Raised when no image with the given ID exists."""
+    """
+    Raised when no image with the given ID exists.
+    """
 
     image_id: int
 
 
 @attrs.frozen
 class ImageNotAssociatedToRecipeError(Exception):
-    """Raised when the image is not linked to the recipe."""
+    """
+    Raised when the image is not linked to the recipe.
+    """
 
     recipe_id: int
     image_id: int
 
 
 def set_cover_image_for_recipe(*, recipe_id: int, image_id: int) -> None:
-    """Set the cover image of a recipe to the given image.
+    """
+    Set the cover image of a recipe to the given image.
 
     Raises:
         RecipeNotFoundError: If no recipe with *recipe_id* exists.
@@ -168,13 +181,16 @@ def set_cover_image_for_recipe(*, recipe_id: int, image_id: int) -> None:
 
 @attrs.frozen
 class RecipeNameValidationError(Exception):
-    """Raised when a recipe name fails validation (too long or non-ASCII)."""
+    """
+    Raised when a recipe name fails validation (too long or non-ASCII).
+    """
 
     name: str
 
 
 def set_recipe_name(*, recipe: models.FujifilmRecipe, name: str) -> None:
-    """Set the name of *recipe* to *name* after validating it.
+    """
+    Set the name of *recipe* to *name* after validating it.
 
     Raises:
         RecipeNameValidationError: If the name is empty, longer than

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -97,7 +97,9 @@ class PathDeltaResult:
 
 
 def decimal_str(value: object) -> str:
-    """Convert a non-null Decimal DB value to a signed string (e.g. Decimal('1.5') → '+1.5')."""
+    """
+    Convert a non-null Decimal DB value to a signed string (e.g. Decimal('1.5') → '+1.5').
+    """
     n = float(value)  # type: ignore[arg-type]
     v: int | float = int(n) if n == int(n) else n
     return f"+{v}" if v > 0 else str(v)
@@ -108,7 +110,9 @@ def _decimal_str_or_none(value: object) -> str | None:
 
 
 def recipe_from_db(*, recipe: models.FujifilmRecipe) -> image_dataclasses.FujifilmRecipeData:
-    """Convert a FujifilmRecipe DB model instance to a FujifilmRecipeData domain object."""
+    """
+    Convert a FujifilmRecipe DB model instance to a FujifilmRecipeData domain object.
+    """
     return recipe_normalization.normalize_recipe_data(
         image_dataclasses.FujifilmRecipeData(
             name=recipe.name,
@@ -154,7 +158,8 @@ class RecipeComparisonResult:
 def get_default_recipe_for_film_simulation(
     *, film_simulation: str,
 ) -> models.FujifilmRecipe | None:
-    """Return the most-used recipe for the given film simulation.
+    """
+    Return the most-used recipe for the given film simulation.
 
     "Most-used" is defined as the recipe linked to the greatest number of images.
     Ties are broken by ascending pk (earliest created recipe wins).
@@ -171,12 +176,16 @@ def get_default_recipe_for_film_simulation(
 
 
 def get_recipes_by_film_simulation(*, film_simulation: str) -> list[models.FujifilmRecipe]:
-    """Return all recipes whose film_simulation matches exactly."""
+    """
+    Return all recipes whose film_simulation matches exactly.
+    """
     return list(models.FujifilmRecipe.objects.filter(film_simulation=film_simulation))
 
 
 def get_distinct_film_simulations() -> list[str]:
-    """Return all distinct film_simulation values present in the recipe table, sorted."""
+    """
+    Return all distinct film_simulation values present in the recipe table, sorted.
+    """
     return list(
         models.FujifilmRecipe.objects
         .values_list("film_simulation", flat=True)
@@ -186,7 +195,8 @@ def get_distinct_film_simulations() -> list[str]:
 
 
 def get_film_simulations_with_multiple_recipes() -> list[str]:
-    """Return film simulations that have more than one recipe, sorted.
+    """
+    Return film simulations that have more than one recipe, sorted.
 
     Film simulations with only one recipe produce a trivial (single-node) graph
     and are excluded from graph filter controls.
@@ -203,7 +213,9 @@ def get_film_simulations_with_multiple_recipes() -> list[str]:
 
 
 def get_image_counts_for_film_simulation(*, film_simulation: str) -> dict[int, int]:
-    """Return a mapping of recipe_id → image count for all recipes with the given film sim."""
+    """
+    Return a mapping of recipe_id → image count for all recipes with the given film sim.
+    """
     from django.db.models import Count
     return {
         row["fujifilm_recipe_id"]: row["count"]
@@ -217,7 +229,9 @@ def get_image_counts_for_film_simulation(*, film_simulation: str) -> dict[int, i
 
 
 def get_image_counts(*, recipe_pks: list[int]) -> dict[int, int]:
-    """Return a mapping of recipe_id → image count for the given recipe PKs."""
+    """
+    Return a mapping of recipe_id → image count for the given recipe PKs.
+    """
     return {
         row["fujifilm_recipe_id"]: row["count"]
         for row in (
@@ -230,7 +244,8 @@ def get_image_counts(*, recipe_pks: list[int]) -> dict[int, int]:
 
 
 def get_recipe_comparison(*, recipe_ids: list[int]) -> RecipeComparisonResult:
-    """Fetch recipes, usage stats, and monthly breakdowns for the given IDs.
+    """
+    Fetch recipes, usage stats, and monthly breakdowns for the given IDs.
 
     Returns a structured result containing all data needed to render a comparison,
     so callers make a single query into the domain rather than issuing multiple
@@ -284,7 +299,9 @@ def get_recipe_comparison(*, recipe_ids: list[int]) -> RecipeComparisonResult:
 
 
 def _field_display_value(field: str, raw: object) -> str | None:
-    """Return a display-ready string for *field*'s value, or None to omit it."""
+    """
+    Return a display-ready string for *field*'s value, or None to omit it.
+    """
     if raw is None:
         return None
     if field in DECIMAL_FIELDS:
@@ -305,7 +322,9 @@ def _recipe_diff_fields(
     a: models.FujifilmRecipe,
     b: models.FujifilmRecipe,
 ) -> tuple[FieldValue, ...]:
-    """Return FieldValues for fields where *a* and *b* differ, with before and after values."""
+    """
+    Return FieldValues for fields where *a* and *b* differ, with before and after values.
+    """
     result = []
     for field in RECIPE_FIELDS:
         if getattr(a, field) != getattr(b, field):
@@ -320,12 +339,15 @@ def _recipe_diff_fields(
 
 
 def get_recipe_all_fields(*, recipe: models.FujifilmRecipe) -> tuple[FieldValue, ...]:
-    """Return all non-None RECIPE_FIELDS of *recipe* as display-ready FieldValue tuples."""
+    """
+    Return all non-None RECIPE_FIELDS of *recipe* as display-ready FieldValue tuples.
+    """
     return _recipe_all_fields(recipe)
 
 
 def get_path_deltas(*, path_ids: list[int]) -> PathDeltaResult:
-    """Compute per-node field deltas for an ordered path through the recipe graph.
+    """
+    Compute per-node field deltas for an ordered path through the recipe graph.
 
     *path_ids* must be ordered root → clicked node. For each recipe:
     - The root (index 0) gets all its non-None field values.
@@ -428,7 +450,8 @@ class RecipeDetailContext:
 
 
 def get_recipe_detail(*, recipe_id: int) -> RecipeDetailContext:
-    """Return the recipe with the given primary key as a RecipeDetailContext.
+    """
+    Return the recipe with the given primary key as a RecipeDetailContext.
 
     The ``cover_image_id`` on the returned ``RecipeData`` is the recipe's explicit
     cover image if one has been set, otherwise the highest-rated image associated
@@ -459,7 +482,8 @@ def get_filtered_recipes(
     active_filters: Mapping[str, Sequence[str]],
     name_search: str = "",
 ) -> list[RecipeData]:
-    """Return all recipes matching the given multi-valued field filters.
+    """
+    Return all recipes matching the given multi-valued field filters.
 
     *active_filters* maps recipe field names to lists of allowed values,
     e.g. ``{"film_simulation": ["Provia", "Classic Chrome"], "grain_roughness": ["Off"]}``.
@@ -495,7 +519,8 @@ def get_recipe_sidebar_filter_options(
     active_filters: Mapping[str, Sequence[str]],
     name_search: str = "",
 ) -> dict[str, dict[str, object]]:
-    """Return faceted filter options for the recipe explorer sidebar.
+    """
+    Return faceted filter options for the recipe explorer sidebar.
 
     For each field in RECIPE_FILTER_FIELDS, counts the number of recipes matching
     that field value while applying all OTHER active filters (faceted search).
@@ -578,7 +603,8 @@ def get_recipe_gallery_data(
     page_number: int | str,
     page_size: int,
 ) -> RecipeGalleryData:
-    """Return all data needed to render the recipe explorer page.
+    """
+    Return all data needed to render the recipe explorer page.
 
     Filters recipes by *active_filters* (multi-valued field lookups), annotates
     each with its image count and the ID of its most popular image (for the card
@@ -638,7 +664,8 @@ def get_recipe_list(
     page_number: int | str,
     page_size: int,
 ) -> RecipeListPage:
-    """Return a paginated list of recipes matching the given field filters.
+    """
+    Return a paginated list of recipes matching the given field filters.
 
     *filters* is a mapping of ORM field lookup kwargs (equality by default),
     e.g. ``{"film_simulation": "Provia"}``.  Pass an empty dict to list all recipes.

--- a/src/domain/recipes/validation.py
+++ b/src/domain/recipes/validation.py
@@ -23,14 +23,17 @@ _ALWAYS_REQUIRED_STR_FIELDS: tuple[str, ...] = (
 
 @attrs.frozen
 class InvalidFujifilmRecipeData(Exception):
-    """Raised when FujifilmRecipeData fails cross-field consistency validation."""
+    """
+    Raised when FujifilmRecipeData fails cross-field consistency validation.
+    """
 
     field: str
     value: object
 
 
 def validate_recipe_data(data: image_dataclasses.FujifilmRecipeData) -> None:
-    """Validate cross-field consistency of *data* before storing in the database.
+    """
+    Validate cross-field consistency of *data* before storing in the database.
 
     Checks that conditional optional fields are present or absent according to
     the values of the fields that control them (d_range_priority, grain_roughness,

--- a/src/interfaces/tasks.py
+++ b/src/interfaces/tasks.py
@@ -10,7 +10,9 @@ from src.domain.images.thumbnails import operations as thumbnail_operations
 
 @shared_task(name="domain.process_image", bind=True, queue=settings.PROCESS_IMAGE_QUEUE)
 def process_image_task(self: Any, /, *, image_path: str, **kwargs: object) -> str:
-    """Celery task that processes a single image and stores its recipe in DB."""
+    """
+    Celery task that processes a single image and stores its recipe in DB.
+    """
     events.publish_event(
         event_type=events.TASK_IMAGE_STARTED,
         image_path=image_path,
@@ -31,6 +33,8 @@ def process_image_task(self: Any, /, *, image_path: str, **kwargs: object) -> st
 
 @shared_task(name="domain.generate_thumbnail", bind=True, queue=settings.PROCESS_IMAGE_QUEUE)
 def generate_thumbnail_task(self: Any, /, *, filepath: str, width: int, **kwargs: object) -> str:
-    """Celery task that generates a thumbnail for a single image file."""
+    """
+    Celery task that generates a thumbnail for a single image file.
+    """
     thumbnail_operations.generate_thumbnail(original_path=Path(filepath), width=width)
     return f"Generated thumbnail for {Path(filepath).name}"

--- a/src/interfaces/templatetags/image_filters.py
+++ b/src/interfaces/templatetags/image_filters.py
@@ -5,13 +5,17 @@ register = template.Library()
 
 @register.filter
 def stars(value: int) -> str:
-    """Return a string of filled star characters for a given integer rating."""
+    """
+    Return a string of filled star characters for a given integer rating.
+    """
     return "★" * int(value)
 
 
 @register.filter
 def signed(value: int | None) -> str:
-    """Format an integer with an explicit sign: +2, 0, -2."""
+    """
+    Format an integer with an explicit sign: +2, 0, -2.
+    """
     if value is None:
         return "0"
     value = int(value)

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -434,7 +434,8 @@ def recipe_graph_view(request: http.HttpRequest, recipe_id: int) -> http.HttpRes
 
 
 def recipe_images_view(request: http.HttpRequest, recipe_id: int) -> http.HttpResponse:
-    """Return thumbnail URLs for all images belonging to a recipe.
+    """
+    Return thumbnail URLs for all images belonging to a recipe.
 
     Images are ordered by rating descending, then taken_at descending.
     Response: JSON ``{"images": [{"id": int, "thumbnail_url": str}]}``.
@@ -454,7 +455,8 @@ def recipe_images_view(request: http.HttpRequest, recipe_id: int) -> http.HttpRe
 
 
 def recipe_compare_image_view(request: http.HttpRequest, recipe_id: int, image_id: int) -> http.HttpResponse:
-    """Return image URLs and prev/next IDs for one image within a recipe sequence.
+    """
+    Return image URLs and prev/next IDs for one image within a recipe sequence.
 
     Response: JSON ``{"id": int, "thumbnail_url": str, "full_url": str, "prev_id": int|null, "next_id": int|null}``.
     """
@@ -537,7 +539,8 @@ def import_recipes_from_uploaded_qr_cards_view(request: http.HttpRequest) -> htt
 
 
 def recipe_path_deltas_view(request: http.HttpRequest) -> http.HttpResponse:
-    """Return per-node field deltas for an ordered path of recipe IDs.
+    """
+    Return per-node field deltas for an ordered path of recipe IDs.
 
     Accepts GET ?ids=1,2,3 where IDs are ordered root → clicked node.
     Returns JSON with root_diffs (root vs clicked) and path_nodes (per-step diffs).

--- a/src/services/events.py
+++ b/src/services/events.py
@@ -8,5 +8,7 @@ TASK_ENQUEUED = "task.enqueued"
 
 
 def publish_event(*, event_type: str, **kwargs: object) -> None:
-    """Publish a structured service event."""
+    """
+    Publish a structured service event.
+    """
     logger.info(event_type, event_type=event_type, **kwargs)

--- a/src/services/workertasks.py
+++ b/src/services/workertasks.py
@@ -9,20 +9,25 @@ from src.services import events
 
 @attrs.frozen
 class TaskNotFoundError(Exception):
-    """Raised when *task_name* cannot be resolved to a Python object."""
+    """
+    Raised when *task_name* cannot be resolved to a Python object.
+    """
 
     task_name: str
 
 
 @attrs.frozen
 class NotACeleryTaskError(Exception):
-    """Raised when *task_name* resolves to an object that is not a Celery task."""
+    """
+    Raised when *task_name* resolves to an object that is not a Celery task.
+    """
 
     task_name: str
 
 
 def enqueue_task(*, task_name: str, kwargs: Mapping[str, object], queue: str) -> None:
-    """Dispatch a Celery task by its dotted Python path to the given queue.
+    """
+    Dispatch a Celery task by its dotted Python path to the given queue.
 
     Use this instead of calling task objects directly to avoid circular imports
     and to keep the application layer decoupled from task implementation details.


### PR DESCRIPTION
All docstrings now have a newline after the opening `"""` and before the closing `"""`, with the summary sentence ending in a period, per the project convention.