### PR TITLE
Small header improvements

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,7 +79,7 @@ Work on a branch in your own fork of the repository. Do not push feature branche
 
 ### Follow the coding conventions
 
-All PRs must satisfy the [Octopus Energy public conventions](https://github.com/octoenergy/public-conventions) in full. Read them before opening a PR. In particular:
+All PRs must satisfy the [Kraken Technologies coding conventions](https://github.com/octoenergy/public-conventions) in full. Read them before opening a PR. In particular:
 
 - **Layered architecture** — place new code in the correct layer. Dependencies must flow inward only.
 - **Django conventions** — serialize template context; don't pass model instances into templates.

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -7,7 +7,7 @@ from src.interfaces import views
 
 urlpatterns = [
     path("static/<path:path>", static_serve, {"document_root": settings.STATIC_FILES_DIR}),
-    path("", RedirectView.as_view(pattern_name="gallery"), name="root"),
+    path("", RedirectView.as_view(pattern_name="recipes-explorer"), name="root"),
     path("images/", views.gallery_view, name="gallery"),
     path("images/results/", views.gallery_results_view, name="gallery-results"),
     path("images/file/<int:image_id>/", views.image_file_view, name="image-file"),

--- a/src/interfaces/templates/_top_nav.html
+++ b/src/interfaces/templates/_top_nav.html
@@ -50,7 +50,9 @@
 </style>
 
 <nav class="top-nav">
-  <img class="top-nav__logo" src="/static/images/filmcase_primary_aligned.svg" alt="Filmcase">
+  <a href="/" style="display: contents;">
+    <img class="top-nav__logo" src="/static/images/filmcase_primary_aligned.svg" alt="Filmcase">
+  </a>
   <a href="{% url 'recipes-explorer' %}" class="top-nav__link{% if active_section == 'recipes' %} top-nav__link--active{% endif %}">Recipes</a>
   <a href="{% url 'gallery' %}" class="top-nav__link{% if active_section == 'images' %} top-nav__link--active{% endif %}">Images</a>
   <a class="top-nav__link{% if active_section == 'camera' %} top-nav__link--active{% endif %}">Camera</a>

--- a/src/interfaces/templates/_top_nav.html
+++ b/src/interfaces/templates/_top_nav.html
@@ -51,7 +51,7 @@
 
 <nav class="top-nav">
   <img class="top-nav__logo" src="/static/images/filmcase_primary_aligned.svg" alt="Filmcase">
-  <a href="{% url 'gallery' %}" class="top-nav__link{% if active_section == 'images' %} top-nav__link--active{% endif %}">Images</a>
   <a href="{% url 'recipes-explorer' %}" class="top-nav__link{% if active_section == 'recipes' %} top-nav__link--active{% endif %}">Recipes</a>
+  <a href="{% url 'gallery' %}" class="top-nav__link{% if active_section == 'images' %} top-nav__link--active{% endif %}">Images</a>
   <a class="top-nav__link{% if active_section == 'camera' %} top-nav__link--active{% endif %}">Camera</a>
 </nav>

--- a/src/interfaces/templates/recipes/recipe_graph.html
+++ b/src/interfaces/templates/recipes/recipe_graph.html
@@ -31,26 +31,30 @@
 
     .sidebar-nav {
       display: flex;
-      flex-direction: column;
+      flex-direction: row;
       gap: 0.25rem;
       margin-bottom: 1.5rem;
     }
 
     .sidebar-nav__link {
-      display: inline-flex;
+      flex: 1;
+      display: flex;
       align-items: center;
-      padding: 0.25rem 0.6rem;
+      justify-content: center;
+      padding: 0.35rem 0.6rem;
       border-radius: 4px;
+      border: 1px solid #ccc;
       font-size: 0.8rem;
       font-weight: 500;
       color: #555;
       text-decoration: none;
       cursor: default;
+      text-align: center;
     }
 
     .sidebar-nav__link[href] { cursor: pointer; }
-    .sidebar-nav__link[href]:hover { background: #f0f0f0; color: #222; }
-    .sidebar-nav__link--active { background: var(--color-accent-light); color: var(--color-accent); font-weight: 600; }
+    .sidebar-nav__link[href]:hover { background: #e8e8e8; color: #222; border-color: #bbb; }
+    .sidebar-nav__link--active { background: var(--color-accent-light); color: var(--color-accent); font-weight: 600; border-color: var(--color-accent); }
 
     .sidebar-recipe-name {
       font-size: 0.95rem;

--- a/tests/functional/test_root_redirect.py
+++ b/tests/functional/test_root_redirect.py
@@ -3,8 +3,8 @@ import pytest
 
 @pytest.mark.django_db
 class TestRootRedirect:
-    def test_root_redirects_to_gallery(self, client):
+    def test_root_redirects_to_recipes(self, client):
         response = client.get("/")
 
         assert response.status_code == 302
-        assert response["Location"] == "/images/"
+        assert response["Location"] == "/recipes/"


### PR DESCRIPTION
## Summary

- Recipes is now the primary section: the top nav shows it first, the root URL redirects to `/recipes/` instead of `/images/`, and clicking the logo navigates to `/` (which redirects to Recipes)
- The recipe graph page's sidebar nav (Explorer / Graph links) is now inline, matching the style already used on the explorer and film-simulation graph pages
- Updated the contributing docs to reference "Kraken Technologies coding conventions" instead of the old "Octopus Energy public conventions" name
