### PR TITLE
Fix push-to-camera spinner and result styles missing outside gallery …

### DIFF
--- a/src/interfaces/templates/recipes/_push_result_partial.html
+++ b/src/interfaces/templates/recipes/_push_result_partial.html
@@ -1,3 +1,71 @@
+<style>
+  .push-result-center {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 220px;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  .push-check-svg {
+    width: 80px;
+    height: 80px;
+    margin-bottom: 1.25rem;
+  }
+
+  .push-check-circle {
+    stroke: var(--color-accent);
+    stroke-width: 2;
+    stroke-dasharray: 166;
+    stroke-dashoffset: 166;
+    stroke-miterlimit: 10;
+    animation: push-stroke 0.6s cubic-bezier(0.65, 0, 0.45, 1) forwards;
+  }
+
+  .push-check-mark {
+    stroke: var(--color-accent);
+    stroke-width: 3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 48;
+    stroke-dashoffset: 48;
+    animation: push-stroke 0.3s cubic-bezier(0.65, 0, 0.45, 1) 0.6s forwards;
+  }
+
+  @keyframes push-stroke { 100% { stroke-dashoffset: 0; } }
+
+  .push-result-message {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #222;
+  }
+
+  .push-result-err-message {
+    font-size: 1rem;
+    color: #dc2626;
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+  }
+
+  .push-retry-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border: 1.5px solid var(--color-accent);
+    border-radius: 12px;
+    background: white;
+    color: var(--color-accent);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .push-retry-btn:hover { background: var(--color-accent-light); }
+</style>
 <button class="slot-card-close" onclick="closeSlotOverlay()" title="Close">&#x2715;</button>
 {% if success %}
 <div class="push-result-center">

--- a/src/interfaces/templates/recipes/recipe_detail.html
+++ b/src/interfaces/templates/recipes/recipe_detail.html
@@ -15,6 +15,62 @@
 
 {% include "recipes/partials/recipe_detail.html" %}
 
+<div id="slot-overlay" hidden></div>
+
+<style>
+  #slot-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0,0,0,0.6);
+  }
+  #slot-overlay[hidden] { display: none; }
+  .slot-card {
+    background: #fff;
+    border-radius: 16px;
+    padding: 2rem;
+    width: 580px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    position: relative;
+    font-family: sans-serif;
+    min-height: 120px;
+    overflow: hidden;
+  }
+  .slot-card--loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .slot-spinner {
+    width: 2rem;
+    height: 2rem;
+    border: 3px solid #e0e0e0;
+    border-top-color: var(--color-accent);
+    border-radius: 50%;
+    animation: slot-spin 0.7s linear infinite;
+  }
+  .slot-push-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 220px;
+    padding: 2rem;
+  }
+  .slot-spinner-large {
+    width: 80px;
+    height: 80px;
+    border: 6px solid #e0e0e0;
+    border-top-color: var(--color-accent);
+    border-radius: 50%;
+    animation: slot-spin 0.7s linear infinite;
+  }
+  @keyframes slot-spin { to { transform: rotate(360deg); } }
+</style>
+
 <script>
   function closeDetail() {
     window.location.href = document.querySelector('.detail-close').href;
@@ -23,8 +79,41 @@
     e.preventDefault();
     closeDetail();
   });
+
+  function closeSlotOverlay() {
+    document.getElementById('slot-overlay').hidden = true;
+  }
+
+  var _slotSpinnerHTML = '<div class="slot-card slot-card--loading"><div class="slot-spinner"></div></div>';
+  var _slotPushLoadingHTML = '<div class="slot-push-loading"><div class="slot-spinner-large"></div></div>';
+
+  document.body.addEventListener('htmx:beforeRequest', function (e) {
+    if (e.detail.target && e.detail.target.id === 'slot-overlay') {
+      var overlay = document.getElementById('slot-overlay');
+      overlay.innerHTML = _slotSpinnerHTML;
+      overlay.hidden = false;
+    }
+    if (e.detail.target && e.detail.target.id === 'slot-card') {
+      e.detail.target.innerHTML = _slotPushLoadingHTML;
+    }
+  });
+
+  document.body.addEventListener('htmx:afterSwap', function (e) {
+    if (e.detail.target.id === 'slot-overlay') {
+      e.detail.target.hidden = false;
+    }
+  });
+
+  document.getElementById('slot-overlay').addEventListener('click', function (e) {
+    if (e.target === this) closeSlotOverlay();
+  });
+
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') closeDetail();
+    if (e.key === 'Escape') {
+      var slotOverlay = document.getElementById('slot-overlay');
+      if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
+      closeDetail();
+    }
   });
 </script>
 

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -376,6 +376,21 @@
       overflow: hidden;
     }
 
+    .slot-card--loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .slot-spinner {
+      width: 2rem;
+      height: 2rem;
+      border: 3px solid #e0e0e0;
+      border-top-color: var(--color-accent);
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+    }
+
     .slot-push-loading {
       display: flex;
       flex-direction: column;
@@ -736,10 +751,21 @@
 
   window._recipeDetailClose = closeRecipeDetail;
 
+  var _slotSpinnerHTML = '<div class="slot-card slot-card--loading"><div class="slot-spinner"></div></div>';
+  var _slotPushLoadingHTML = '<div class="slot-push-loading"><div class="slot-spinner-large"></div></div>';
+
   document.body.addEventListener('htmx:beforeRequest', function (e) {
     if (e.detail.target && e.detail.target.id === 'recipe-detail-overlay') {
       var detailOverlay = document.getElementById('recipe-detail-overlay');
       if (detailOverlay.hidden) _explorerUrl = window.location.href;
+    }
+    if (e.detail.target && e.detail.target.id === 'slot-overlay') {
+      var overlay = document.getElementById('slot-overlay');
+      overlay.innerHTML = _slotSpinnerHTML;
+      overlay.hidden = false;
+    }
+    if (e.detail.target && e.detail.target.id === 'slot-card') {
+      e.detail.target.innerHTML = _slotPushLoadingHTML;
     }
   });
 


### PR DESCRIPTION
## Summary

After https://github.com/gosku/Filmcase/pull/29, the push-to-camera modal was broken on the recipe detail and explorer pages: after clicking a slot, the result appeared as a plain white card with unstyled text instead of the animated SVG checkmark. The loading spinner also never appeared while waiting for the camera request to complete — both when fetching the slot list and when pushing the recipe.

Root cause: all the relevant CSS (animated check, spinners) and the `htmx:beforeRequest` JS that injects the spinner HTML before a request fires were defined exclusively in `gallery.html`. The other two contexts that use the same HTMX flow had none of it.

**Three files fixed:**

- **`_push_result_partial.html`** — added a `<style>` block with the push result CSS (animated SVG circle/checkmark, error message, retry button) so it travels with the partial regardless of which page loads it.
- **`recipes_explorer.html`** — added `.slot-card--loading` / `.slot-spinner` CSS (missing entirely) and wired up `htmx:beforeRequest` to inject the spinner HTML into the slot overlay and slot card before each request.
- **`recipe_detail.html`** (standalone page) — added the full slot overlay infrastructure that was absent: `#slot-overlay` div, all slot/spinner CSS, `closeSlotOverlay()`, and the `htmx:beforeRequest` / `htmx:afterSwap` / click / Escape handlers.
