### PR TITLE
Enhance ux of htmx pages

### DIFF
--- a/src/interfaces/templates/images/_image_detail_partial.html
+++ b/src/interfaces/templates/images/_image_detail_partial.html
@@ -320,7 +320,7 @@
     <div class="detail-header-spacer"></div>
     {% include "images/_rating_widget.html" with image_id=image.id rating=image.rating %}
     <a href="{% url 'gallery' %}" class="detail-close" title="Close"
-       onclick="event.preventDefault(); (window._detailClose || function(){ history.back(); })();">&#x2715;</a>
+       onclick="event.preventDefault(); (window._detailClose || window.closeImageDetail || function(){ history.back(); })();">&#x2715;</a>
   </header>
 
   <div class="detail-body">

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -596,23 +596,22 @@
   });
 
   // Detail overlay logic.
-  var _galleryUrl = null;
 
   function closeDetail() {
     document.getElementById('detail-overlay').hidden = true;
     document.querySelector('.gallery-scroll').style.overflow = '';
-    if (_galleryUrl) {
-      history.replaceState(null, '', _galleryUrl);
-      _galleryUrl = null;
-    }
+    var params = new URLSearchParams(window.location.search);
+    history.replaceState(null, '', '/images/' + (params.toString() ? '?' + params.toString() : ''));
   }
 
   window._detailClose = closeDetail;
 
-  document.body.addEventListener('htmx:beforeRequest', function (e) {
+  document.body.addEventListener('htmx:beforeHistoryUpdate', function (e) {
     if (e.detail.target && e.detail.target.id === 'detail-overlay') {
-      var overlay = document.getElementById('detail-overlay');
-      if (overlay.hidden) _galleryUrl = window.location.href;
+      var params = new URLSearchParams(window.location.search);
+      if (params.toString()) {
+        e.detail.history.path = e.detail.history.path + '?' + params.toString();
+      }
     }
   });
 

--- a/src/interfaces/templates/images/image_detail.html
+++ b/src/interfaces/templates/images/image_detail.html
@@ -530,6 +530,24 @@
 
   var preloadedUrls = new Set();
 
+  // On direct page load the overlay is pre-rendered, so htmx:afterSwap never
+  // fires. Run the same full-size loading logic immediately on DOMContentLoaded.
+  document.addEventListener('DOMContentLoaded', function () {
+    var overlay = document.getElementById('detail-overlay');
+    var img = overlay && overlay.querySelector('.detail-image');
+    if (!img || !img.dataset.fullSrc) return;
+    var fullSrc = img.dataset.fullSrc;
+    var full = new Image();
+    full.onload = function () {
+      img.src = fullSrc;
+      var nextUrl = overlay.querySelector('.detail-nav-next')?.dataset.preloadUrl;
+      var prevUrl = overlay.querySelector('.detail-nav-prev')?.dataset.preloadUrl;
+      if (nextUrl) { var n = new Image(); n.onload = function () { preloadedUrls.add(nextUrl); }; n.src = nextUrl; }
+      if (prevUrl) { var p = new Image(); p.onload = function () { preloadedUrls.add(prevUrl); }; p.src = prevUrl; }
+    };
+    full.src = fullSrc;
+  });
+
   window.closeImageDetail = function () {
     document.getElementById('detail-overlay').hidden = true;
     document.querySelector('.gallery-scroll').style.overflow = '';

--- a/src/interfaces/templates/images/image_detail.html
+++ b/src/interfaces/templates/images/image_detail.html
@@ -4,26 +4,586 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ image.filename }}</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tom-select@2/dist/css/tom-select.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/tom-select@2/dist/js/tom-select.complete.min.js"></script>
+  <link rel="stylesheet" href="/static/css/brand.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { height: 100%; overflow: hidden; }
-    body { background: #111; display: flex; flex-direction: column; }
+    body { display: flex; flex-direction: column; font-family: sans-serif; height: 100vh; overflow: hidden; }
+
+    .content-area { display: flex; flex: 1; overflow: hidden; min-height: 0; }
+
+    .sidebar {
+      width: 320px;
+      min-width: 320px;
+      padding: 1.5rem;
+      border-right: 1px solid #e0e0e0;
+      overflow-y: auto;
+      background: var(--color-bg-surface);
+    }
+
+    .filter-group {
+      margin-bottom: 1.2rem;
+    }
+
+    .filter-label {
+      display: block;
+      font-weight: 600;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #444;
+      margin-bottom: 0.35rem;
+    }
+
+    .filter-select {
+      width: 100%;
+      padding: 0.4rem 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      background: #fff;
+      cursor: pointer;
+    }
+
+    .ts-wrapper { width: 100%; }
+    .ts-control { font-size: 0.9rem; }
+    .ts-wrapper.single.has-items .ts-control input { width: 0; min-width: 0; }
+
+    .clear-filters-btn {
+      display: block;
+      width: 100%;
+      padding: 0.35rem 0.5rem;
+      margin-bottom: 1.2rem;
+      background: none;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      color: #666;
+      cursor: pointer;
+      text-align: center;
+      text-decoration: none;
+    }
+
+    .clear-filters-btn:hover {
+      background: #f0f0f0;
+      color: #333;
+    }
+
+    .filter-checkboxes {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+      max-height: 180px;
+      overflow-y: auto;
+    }
+
+    .filter-option {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      padding: 0.1rem 0.2rem;
+      border-radius: 3px;
+      color: #333;
+      user-select: none;
+    }
+
+    .filter-option input[type="checkbox"] {
+      accent-color: var(--color-accent);
+    }
+
+    .filter-option:hover { background: #f0f0f0; }
+
+    .filter-option--unavailable { color: #bbb; }
+
+    .filter-option--unavailable input[type="checkbox"] { opacity: 0.4; }
+
+    .filter-option-value {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .filter-option-count {
+      font-size: 0.75rem;
+      color: #999;
+      flex-shrink: 0;
+    }
+
+    .filter-option--unavailable .filter-option-count { color: #ccc; }
+
+    .main {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .gallery-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0 2rem 2rem;
+    }
+
+    .rating-toggle {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: #555;
+      user-select: none;
+    }
+
+    .rating-toggle input[type="checkbox"] {
+      appearance: none;
+      width: 2rem;
+      height: 1.1rem;
+      background: #ccc;
+      border-radius: 1rem;
+      position: relative;
+      cursor: pointer;
+      transition: background 0.2s;
+      flex-shrink: 0;
+    }
+
+    .rating-toggle input[type="checkbox"]:checked { background: var(--color-accent); }
+
+    .rating-toggle input[type="checkbox"]::after {
+      content: '';
+      position: absolute;
+      width: 0.85rem;
+      height: 0.85rem;
+      background: #fff;
+      border-radius: 50%;
+      top: 0.125rem;
+      left: 0.125rem;
+      transition: left 0.2s;
+    }
+
+    .rating-toggle input[type="checkbox"]:checked::after {
+      left: calc(100% - 0.975rem);
+    }
+
+    #gallery-results {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+    }
+
+    .infinite-scroll-sentinel {
+      height: 300px;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .image-card {
+      min-width: 0;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 0.5rem;
+      background: #fff;
+    }
+
+    .image-thumbnail {
+      width: 100%;
+      height: 300px;
+      object-fit: contain;
+      display: block;
+      border-radius: 4px;
+      margin-bottom: 0.5rem;
+      background: #f0f0f0;
+    }
+
+    .image-recipe {
+      display: block;
+      font-weight: 600;
+      font-size: 1rem;
+      color: #222;
+      margin-bottom: 0.15rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .image-meta-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 0.5rem;
+      margin-bottom: 0.15rem;
+    }
+
+    .image-exposure { font-size: 0.9rem; color: #555; }
+
+    .image-filename {
+      font-size: 0.85rem;
+      color: #888;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: right;
+    }
+
+    .recipe-labels {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      margin-bottom: 0.3rem;
+    }
+
+    .recipe-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      white-space: nowrap;
+    }
+
+    .rl-dr, .rl-drp, .rl-gr, .rl-gs, .rl-cce, .rl-ccfx,
+    .rl-wb, .rl-r, .rl-b, .rl-hl, .rl-sh, .rl-co, .rl-srp,
+    .rl-ns, .rl-cl {
+      background: #eef0f3;
+      color: #3d4754;
+    }
+
+    .image-rating {
+      display: inline-block;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--color-accent);
+      background: var(--color-accent-light);
+      border-radius: 3px;
+      padding: 0.1rem 0.4rem;
+    }
+
+    .no-results {
+      grid-column: 1 / -1;
+      color: #888;
+      font-style: italic;
+    }
+
+    #detail-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      overflow: hidden;
+    }
+
+    #detail-overlay .detail-overlay { height: 100%; }
+
+    #slot-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.6);
+    }
+
+    #slot-overlay[hidden] { display: none; }
+
+    .slot-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 2rem;
+      width: 580px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+      position: relative;
+      font-family: sans-serif;
+      min-height: 120px;
+      overflow: hidden;
+    }
+
+    .slot-card--loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .slot-spinner {
+      width: 2rem;
+      height: 2rem;
+      border: 3px solid #e0e0e0;
+      border-top-color: var(--color-accent);
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+    }
+
+    @keyframes slot-spin { to { transform: rotate(360deg); } }
+
+    .slot-push-loading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 220px;
+      padding: 2rem;
+    }
+
+    .slot-spinner-large {
+      width: 80px;
+      height: 80px;
+      border: 6px solid #e0e0e0;
+      border-top-color: var(--color-accent);
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+    }
+
+    .push-result-center {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 220px;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    .push-check-svg { width: 80px; height: 80px; margin-bottom: 1.25rem; }
+
+    .push-check-circle {
+      stroke: var(--color-accent);
+      stroke-width: 2;
+      stroke-dasharray: 166;
+      stroke-dashoffset: 166;
+      stroke-miterlimit: 10;
+      animation: push-stroke 0.6s cubic-bezier(0.65, 0, 0.45, 1) forwards;
+    }
+
+    .push-check-mark {
+      stroke: var(--color-accent);
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 48;
+      stroke-dashoffset: 48;
+      animation: push-stroke 0.3s cubic-bezier(0.65, 0, 0.45, 1) 0.6s forwards;
+    }
+
+    @keyframes push-stroke { 100% { stroke-dashoffset: 0; } }
+
+    .push-result-message { font-size: 1.3rem; font-weight: 700; color: #222; }
+
+    .push-result-err-message {
+      font-size: 1rem;
+      color: #dc2626;
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+
+    .push-retry-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.75rem 1.5rem;
+      border: 1.5px solid var(--color-accent);
+      border-radius: 12px;
+      background: white;
+      color: var(--color-accent);
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .push-retry-btn:hover { background: var(--color-accent-light); }
   </style>
 </head>
 <body>
 
-{% include "images/_image_detail_partial.html" %}
+{% include "_top_nav.html" with active_section="images" %}
+
+<div class="content-area">
+
+<aside class="sidebar">
+  <a href="{% url 'gallery' %}" class="clear-filters-btn">Clear all filters</a>
+  <form id="filter-form"
+        hx-get="{% url 'gallery' %}"
+        hx-trigger="change"
+        hx-target="#gallery-results"
+        hx-push-url="true">
+    <div class="filter-group">
+      <label class="rating-toggle" for="rating-first-toggle">
+        <input type="checkbox" id="rating-first-toggle">
+        Sort by rating
+      </label>
+      <input type="hidden" name="rating_first" id="rating-first-input" value="{{ request.GET.rating_first|default:'1' }}">
+    </div>
+    <div id="recipe-filter"></div>
+    <div id="sidebar-filters"></div>
+  </form>
+</aside>
+
+<main class="main">
+  <div class="gallery-scroll" style="padding-top: 1.5rem;">
+    <div id="gallery-results"
+         hx-get="{% url 'gallery' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+         hx-trigger="load"
+         hx-target="#gallery-results"
+         hx-swap="innerHTML">
+    </div>
+    <div id="load-more-sentinel"></div>
+  </div>
+</main>
+
+</div><!-- .content-area -->
+
+<div id="detail-overlay">
+  {% include "images/_image_detail_partial.html" %}
+</div>
+<div id="slot-overlay" hidden></div>
 
 <script>
-  function closeDetail() {
-    window.location.href = document.querySelector('.detail-close').href;
+  function initRecipeSelects() {
+    document.querySelectorAll('.filter-select-search').forEach(function (el) {
+      if (el.tomselect) return;
+      new TomSelect(el, {
+        create: false,
+        plugins: ['remove_button'],
+        onChange: function () {
+          document.getElementById('filter-form').dispatchEvent(new Event('change'));
+        },
+      });
+    });
   }
-  document.querySelector('.detail-close').addEventListener('click', function (e) {
-    e.preventDefault();
-    closeDetail();
+  initRecipeSelects();
+
+  document.body.addEventListener('htmx:oobBeforeSwap', function (evt) {
+    if (!evt.detail.target || evt.detail.target.id !== 'recipe-filter') return;
+    var select = evt.detail.target.querySelector('.filter-select-search');
+    if (!select || !select.tomselect) return;
+    var newSelect = evt.detail.fragment.querySelector('select');
+    if (!newSelect) return;
+    var ts = select.tomselect;
+    var newOpts = Array.from(newSelect.querySelectorAll('option')).map(function (opt) {
+      return { value: opt.value, text: opt.textContent.trim() };
+    });
+    ts.clearOptions();
+    ts.addOptions(newOpts);
+    ts.refreshOptions(false);
+    evt.detail.shouldSwap = false;
   });
+
+  (function () {
+    var urlParams = new URLSearchParams(window.location.search);
+    var hiddenInput = document.getElementById('rating-first-input');
+    var toggle = document.getElementById('rating-first-toggle');
+
+    var val;
+    if (urlParams.has('rating_first')) {
+      val = urlParams.get('rating_first');
+    } else {
+      val = localStorage.getItem('ratingFirst') ?? '1';
+      urlParams.set('rating_first', val);
+      history.replaceState(null, '', '?' + urlParams.toString());
+    }
+
+    hiddenInput.value = val;
+    toggle.checked = val === '1';
+
+    toggle.addEventListener('change', function () {
+      var newVal = toggle.checked ? '1' : '0';
+      localStorage.setItem('ratingFirst', newVal);
+      hiddenInput.value = newVal;
+      document.getElementById('filter-form').dispatchEvent(new Event('change'));
+    });
+  })();
+
+  document.body.addEventListener('htmx:afterSettle', function (e) {
+    if (e.detail.target && e.detail.target.id === 'gallery-results') {
+      initRecipeSelects();
+    }
+  });
+
+  document.body.addEventListener('htmx:afterSwap', function (e) {
+    if (e.detail.target.id !== 'detail-overlay') return;
+    var overlay = e.detail.target;
+    overlay.hidden = false;
+    document.querySelector('.gallery-scroll').style.overflow = 'hidden';
+
+    var img = overlay.querySelector('.detail-image');
+    if (!img || !img.dataset.fullSrc) return;
+    var fullSrc = img.dataset.fullSrc;
+
+    function afterFullLoaded() {
+      img.src = fullSrc;
+      var nextUrl = overlay.querySelector('.detail-nav-next')?.dataset.preloadUrl;
+      var prevUrl = overlay.querySelector('.detail-nav-prev')?.dataset.preloadUrl;
+      if (nextUrl && !preloadedUrls.has(nextUrl)) {
+        var n = new Image(); n.onload = function () { preloadedUrls.add(nextUrl); }; n.src = nextUrl;
+      }
+      if (prevUrl && !preloadedUrls.has(prevUrl)) {
+        var p = new Image(); p.onload = function () { preloadedUrls.add(prevUrl); }; p.src = prevUrl;
+      }
+    }
+
+    if (preloadedUrls.has(fullSrc)) { afterFullLoaded(); }
+    else { var full = new Image(); full.onload = afterFullLoaded; full.src = fullSrc; }
+  });
+
+  var preloadedUrls = new Set();
+
+  window.closeImageDetail = function () {
+    document.getElementById('detail-overlay').hidden = true;
+    document.querySelector('.gallery-scroll').style.overflow = '';
+    var params = new URLSearchParams(window.location.search);
+    history.replaceState(null, '', '/images/' + (params.toString() ? '?' + params.toString() : ''));
+  };
+
+  function closeSlotOverlay() {
+    document.getElementById('slot-overlay').hidden = true;
+  }
+
+  var _slotSpinnerHTML = '<div class="slot-card slot-card--loading"><div class="slot-spinner"></div></div>';
+  var _slotPushLoadingHTML = '<div class="slot-push-loading"><div class="slot-spinner-large"></div></div>';
+
+  document.body.addEventListener('htmx:beforeRequest', function (e) {
+    if (e.detail.target && e.detail.target.id === 'slot-overlay') {
+      var overlay = document.getElementById('slot-overlay');
+      overlay.innerHTML = _slotSpinnerHTML;
+      overlay.hidden = false;
+    }
+    if (e.detail.target && e.detail.target.id === 'slot-card') {
+      e.detail.target.innerHTML = _slotPushLoadingHTML;
+    }
+  });
+
+  document.body.addEventListener('htmx:afterSwap', function (e) {
+    if (e.detail.target.id === 'slot-overlay') {
+      e.detail.target.hidden = false;
+    }
+  });
+
+  document.body.addEventListener('htmx:beforeHistoryUpdate', function (e) {
+    if (e.detail.target && e.detail.target.id === 'detail-overlay') {
+      var params = new URLSearchParams(window.location.search);
+      if (params.toString()) {
+        e.detail.history.path = e.detail.history.path + '?' + params.toString();
+      }
+    }
+  });
+
+  document.getElementById('slot-overlay').addEventListener('click', function (e) {
+    if (e.target === this) closeSlotOverlay();
+  });
+
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') closeDetail();
+    if (e.key === 'Escape') {
+      var slotOverlay = document.getElementById('slot-overlay');
+      if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
+    }
+    var overlay = document.getElementById('detail-overlay');
+    if (!overlay || overlay.hidden) return;
+    if (e.key === 'Escape') window.closeImageDetail();
+    if (e.key === 'ArrowLeft') { var btn = overlay.querySelector('.detail-nav-prev'); if (btn) btn.click(); }
+    if (e.key === 'ArrowRight') { var btn = overlay.querySelector('.detail-nav-next'); if (btn) btn.click(); }
   });
 </script>
 

--- a/src/interfaces/templates/recipes/partials/recipe_detail.html
+++ b/src/interfaces/templates/recipes/partials/recipe_detail.html
@@ -298,7 +298,7 @@
     {% endif %}
     {% include "recipes/_recipe_name_prompt.html" with recipe=recipe %}
     <a href="{% url 'recipes-explorer' %}" class="detail-close" title="Close"
-       onclick="event.preventDefault(); (window._recipeDetailClose || function(){ history.back(); })();">&#x2715;</a>
+       onclick="event.preventDefault(); (window._recipeDetailClose || window.closeRecipeDetail || function(){ history.back(); })();">&#x2715;</a>
   </header>
 
   <div class="detail-body">

--- a/src/interfaces/templates/recipes/recipe_detail.html
+++ b/src/interfaces/templates/recipes/recipe_detail.html
@@ -761,6 +761,8 @@
 
   document.addEventListener('keydown', function (e) {
     if (e.key !== 'Escape') return;
+    var cardOverlay = document.getElementById('card-overlay');
+    if (cardOverlay && !cardOverlay.hidden) return;
     var slotOverlay = document.getElementById('slot-overlay');
     if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
     var detailOverlay = document.getElementById('recipe-detail-overlay');

--- a/src/interfaces/templates/recipes/recipe_detail.html
+++ b/src/interfaces/templates/recipes/recipe_detail.html
@@ -4,81 +4,719 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% if recipe.name %}{{ recipe.name }}{% else %}{{ recipe.film_simulation }} #{{ recipe.id }}{% endif %}</title>
+  <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="/static/css/brand.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { height: 100%; overflow: hidden; }
-    body { background: #1a1a1a; display: flex; flex-direction: column; }
+    body { display: flex; flex-direction: column; font-family: sans-serif; height: 100vh; overflow: hidden; }
+
+    .content-area { display: flex; flex: 1; overflow: hidden; min-height: 0; }
+
+    .sidebar {
+      width: 320px;
+      min-width: 320px;
+      padding: 1.5rem;
+      border-right: 1px solid #e0e0e0;
+      overflow-y: auto;
+      background: var(--color-bg-surface);
+    }
+
+    .sidebar h2 {
+      font-size: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #666;
+      margin-bottom: 1.5rem;
+    }
+
+    .sidebar-nav {
+      display: flex;
+      flex-direction: row;
+      gap: 0.25rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .sidebar-nav__link {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.35rem 0.6rem;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      font-size: 0.8rem;
+      font-weight: 500;
+      color: #555;
+      text-decoration: none;
+      cursor: default;
+      text-align: center;
+    }
+
+    .sidebar-nav__link[href] {
+      cursor: pointer;
+    }
+
+    .sidebar-nav__link[href]:hover {
+      background: #e8e8e8;
+      color: #222;
+      border-color: #bbb;
+    }
+
+    .sidebar-nav__link--active {
+      background: var(--color-accent-light);
+      color: var(--color-accent);
+      font-weight: 600;
+      border-color: var(--color-accent);
+    }
+
+    .recipe-name-search {
+      display: block;
+      width: 100%;
+      padding: 0.35rem 0.5rem;
+      margin-bottom: 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      color: #333;
+      background: #fff;
+    }
+
+    .recipe-name-search:focus {
+      outline: none;
+      border-color: var(--color-accent);
+    }
+
+    .clear-filters-btn {
+      display: block;
+      width: 100%;
+      padding: 0.35rem 0.5rem;
+      margin-bottom: 1.2rem;
+      background: none;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      color: #666;
+      cursor: pointer;
+      text-align: center;
+      text-decoration: none;
+    }
+
+    .clear-filters-btn:hover {
+      background: #f0f0f0;
+      color: #333;
+    }
+
+    .filter-group {
+      margin-bottom: 1.2rem;
+    }
+
+    .filter-label {
+      display: block;
+      font-weight: 600;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #444;
+      margin-bottom: 0.35rem;
+    }
+
+    .filter-checkboxes {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+      max-height: 180px;
+      overflow-y: auto;
+    }
+
+    .filter-option {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      cursor: pointer;
+      padding: 0.1rem 0.2rem;
+      border-radius: 3px;
+      color: #333;
+      user-select: none;
+    }
+
+    .filter-option input[type="checkbox"] {
+      accent-color: var(--color-accent);
+    }
+
+    .filter-option:hover { background: #f0f0f0; }
+
+    .filter-option--unavailable {
+      color: #bbb;
+    }
+
+    .filter-option--unavailable input[type="checkbox"] {
+      opacity: 0.4;
+    }
+
+    .filter-option-value {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .filter-option-count {
+      font-size: 0.75rem;
+      color: #999;
+      flex-shrink: 0;
+    }
+
+    .filter-option--unavailable .filter-option-count {
+      color: #ccc;
+    }
+
+    .main {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .gallery-header {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding: 1rem 2rem;
+      flex-shrink: 0;
+    }
+
+    .recipe-gallery-scroll {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0 2rem 2rem;
+    }
+
+    #recipe-gallery-results {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1rem;
+    }
+
+    .infinite-scroll-sentinel {
+      height: 300px;
+      visibility: hidden;
+      pointer-events: none;
+    }
+
+    .recipe-card {
+      position: relative;
+      height: 260px;
+      border-radius: 8px;
+      overflow: hidden;
+      background: #1a1a1a no-repeat center/cover;
+    }
+
+    .recipe-card__overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      padding: 0.75rem;
+      background: linear-gradient(to top, rgba(0,0,0,0.72) 0%, transparent 55%);
+    }
+
+    .recipe-card__bottom {
+      display: flex;
+      align-items: flex-end;
+      gap: 0.5rem;
+    }
+
+    .recipe-card__logo {
+      width: 46.4px;
+      height: 46.4px;
+      flex-shrink: 0;
+      object-fit: contain;
+      filter: drop-shadow(0 1px 2px rgba(0,0,0,0.6));
+    }
+
+    .recipe-card__info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .recipe-card__name {
+      display: block;
+      color: #fff;
+      font-weight: 700;
+      font-size: 1.2rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .recipe-card__count {
+      display: block;
+      color: rgba(255,255,255,0.75);
+      font-size: 0.75rem;
+      margin-top: 0.15rem;
+    }
+
+    .no-results {
+      grid-column: 1 / -1;
+      color: #888;
+      font-style: italic;
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-left: auto;
+    }
+
+    .create-recipe-link-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.4rem 0.85rem;
+      background: var(--color-accent);
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+
+    .create-recipe-link-btn:hover { background: var(--color-accent-dark); }
+
+    .create-recipes-wrap {
+      position: relative;
+    }
+
+    .create-recipes-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.4rem 0.85rem;
+      background: var(--color-accent);
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .create-recipes-btn:hover { background: var(--color-accent-dark); }
+
+    .create-recipes-dropdown {
+      position: absolute;
+      top: calc(100% + 6px);
+      right: 0;
+      min-width: 260px;
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+      z-index: 100;
+      overflow: hidden;
+    }
+
+    .create-recipes-dropdown[hidden] { display: none; }
+
+    .create-recipes-option {
+      display: block;
+      width: 100%;
+      padding: 0.65rem 1rem;
+      background: none;
+      border: none;
+      text-align: left;
+      font-size: 0.875rem;
+      color: #333;
+      cursor: pointer;
+    }
+
+    .create-recipes-option:hover { background: #f5f5f5; }
+
+    #recipe-detail-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      overflow: hidden;
+    }
+
+    #recipe-detail-overlay .detail-overlay {
+      height: 100%;
+    }
+
+    #slot-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.6);
+    }
+
+    #slot-overlay[hidden] { display: none; }
+
+    .slot-card {
+      background: #fff;
+      border-radius: 16px;
+      padding: 2rem;
+      width: 580px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+      position: relative;
+      font-family: sans-serif;
+      min-height: 120px;
+      overflow: hidden;
+    }
+
+    .slot-card--loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .slot-spinner {
+      width: 2rem;
+      height: 2rem;
+      border: 3px solid #e0e0e0;
+      border-top-color: var(--color-accent);
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+    }
+
+    .slot-push-loading {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 220px;
+      padding: 2rem;
+    }
+
+    .slot-spinner-large {
+      width: 80px;
+      height: 80px;
+      border: 6px solid #e0e0e0;
+      border-top-color: var(--color-accent);
+      border-radius: 50%;
+      animation: slot-spin 0.7s linear infinite;
+    }
+
+    @keyframes slot-spin { to { transform: rotate(360deg); } }
+
+    .import-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.45);
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .import-overlay[hidden] { display: none; }
+
+    .import-modal {
+      background: #fff;
+      border-radius: 10px;
+      padding: 2rem;
+      width: 480px;
+      max-width: calc(100vw - 2rem);
+      max-height: calc(100vh - 4rem);
+      overflow-y: auto;
+      position: relative;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    }
+
+    .import-modal__close {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      background: none;
+      border: none;
+      font-size: 1.4rem;
+      color: #888;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0.2rem 0.4rem;
+    }
+
+    .import-modal__close:hover { color: #333; }
+
+    .import-modal h2 {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #222;
+      margin-bottom: 0.5rem;
+    }
+
+    .import-modal__desc {
+      font-size: 0.875rem;
+      color: #666;
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+
+    .upload-from-computer-btn {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      background: #f3f4f6;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #333;
+      cursor: pointer;
+    }
+
+    .upload-from-computer-btn:hover { background: #e8e8e8; }
+
+    #import-file-input { display: none; }
+
+    .selected-files-list {
+      margin: 1rem 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .selected-files-list li {
+      font-size: 0.825rem;
+      color: #444;
+      padding: 0.2rem 0;
+      border-bottom: 1px solid #f0f0f0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .import-submit-btn {
+      display: block;
+      width: 100%;
+      margin-top: 1.25rem;
+      padding: 0.6rem 1rem;
+      background: var(--color-accent);
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 0.9rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .import-submit-btn:hover { background: var(--color-accent-dark); }
+    .import-submit-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+    .import-result { margin-top: 1.25rem; }
+
+    .import-result__message { font-size: 0.875rem; margin-bottom: 0.35rem; }
+    .import-result__message--success { color: var(--color-accent); font-weight: 600; }
+    .import-result__message--warning { color: #b36b2d; font-weight: 600; }
+    .import-result--error .import-result__message { color: #c0392b; }
+
+    .import-result__failed-list {
+      margin: 0.25rem 0 0 1rem;
+      font-size: 0.8rem;
+      color: #666;
+    }
   </style>
 </head>
 <body>
 
-{% include "recipes/partials/recipe_detail.html" %}
+{% include "_top_nav.html" with active_section="recipes" %}
 
-<div id="slot-overlay" hidden></div>
+<div class="content-area">
 
-<style>
-  #slot-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 200;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0,0,0,0.6);
-  }
-  #slot-overlay[hidden] { display: none; }
-  .slot-card {
-    background: #fff;
-    border-radius: 16px;
-    padding: 2rem;
-    width: 580px;
-    box-shadow: 0 4px 24px rgba(0,0,0,0.2);
-    position: relative;
-    font-family: sans-serif;
-    min-height: 120px;
-    overflow: hidden;
-  }
-  .slot-card--loading {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-  .slot-spinner {
-    width: 2rem;
-    height: 2rem;
-    border: 3px solid #e0e0e0;
-    border-top-color: var(--color-accent);
-    border-radius: 50%;
-    animation: slot-spin 0.7s linear infinite;
-  }
-  .slot-push-loading {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 220px;
-    padding: 2rem;
-  }
-  .slot-spinner-large {
-    width: 80px;
-    height: 80px;
-    border: 6px solid #e0e0e0;
-    border-top-color: var(--color-accent);
-    border-radius: 50%;
-    animation: slot-spin 0.7s linear infinite;
-  }
-  @keyframes slot-spin { to { transform: rotate(360deg); } }
-</style>
+  <aside class="sidebar">
+    <nav class="sidebar-nav">
+      <a class="sidebar-nav__link sidebar-nav__link--active">Explorer</a>
+      <a href="{% url 'recipes-graph' %}" class="sidebar-nav__link">Graph</a>
+    </nav>
+    <a href="{% url 'recipes-explorer' %}" class="clear-filters-btn">Clear all filters</a>
+    <form id="recipe-filter-form"
+          hx-get="{% url 'recipes-explorer' %}"
+          hx-trigger="change, input delay:300ms from:#recipe-name-search"
+          hx-target="#recipe-gallery-results"
+          hx-push-url="true">
+      <input id="recipe-name-search"
+             type="search"
+             name="name_search"
+             class="recipe-name-search"
+             placeholder="Search by name…"
+             value="{{ request.GET.name_search }}">
+      <div id="recipe-sidebar-filters"></div>
+    </form>
+  </aside>
+
+  <main class="main">
+    <div class="gallery-header">
+      <div class="header-actions">
+        <a href="{% url 'create-recipe' %}" class="create-recipe-link-btn">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+          Create Recipe
+        </a>
+        <div class="create-recipes-wrap">
+          <button class="create-recipes-btn" id="create-recipes-btn">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+            </svg>
+            Import Recipes
+          </button>
+          <div class="create-recipes-dropdown" id="create-recipes-dropdown" hidden>
+            <button class="create-recipes-option open-import-modal-btn"
+                    data-import-url="{% url 'recipes-import' %}"
+                    data-import-title="Import Recipes from Images"
+                    data-import-desc="Select one or more Fujifilm JPEG files. The recipe settings encoded in their EXIF data will be extracted and saved — the image files themselves are not stored.">
+              Import recipes from images
+            </button>
+            <button class="create-recipes-option open-import-modal-btn"
+                    data-import-url="{% url 'recipes-import-qr-cards' %}"
+                    data-import-title="Import Recipes from Cards"
+                    data-import-desc="Select one or more recipe-card JPEGs. The recipe encoded in each card's QR code will be extracted and saved — the card images themselves are not stored.">
+              Import recipes from recipe cards
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Import modal -->
+    <div class="import-overlay" id="import-overlay" hidden>
+      <div class="import-modal" role="dialog" aria-modal="true" aria-labelledby="import-modal-title">
+        <button class="import-modal__close" id="close-import-modal-btn" aria-label="Close">&#x2715;</button>
+        <h2 id="import-modal-title">Import Recipes from Images</h2>
+        <p class="import-modal__desc">
+          Select one or more Fujifilm JPEG files. The recipe settings encoded in
+          their EXIF data will be extracted and saved — the image files themselves
+          are not stored.
+        </p>
+
+        <form id="import-form"
+              hx-post="{% url 'recipes-import' %}"
+              hx-encoding="multipart/form-data"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-target="#import-result"
+              hx-swap="innerHTML"
+              hx-disabled-elt="#import-submit-btn">
+
+          <label class="upload-from-computer-btn" for="import-file-input">
+            Upload from computer
+          </label>
+          <input type="file" id="import-file-input" name="images"
+                 multiple accept=".jpg,.jpeg">
+
+          <ul class="selected-files-list" id="selected-files-list" hidden></ul>
+
+          <button type="submit" class="import-submit-btn" id="import-submit-btn" hidden>
+            Import Recipes from Images
+          </button>
+        </form>
+
+        <div id="import-result"></div>
+      </div>
+    </div>
+
+    <div class="recipe-gallery-scroll">
+      <div id="recipe-gallery-results" class="recipe-grid"
+           hx-get="{% url 'recipes-explorer' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
+           hx-trigger="load"
+           hx-target="#recipe-gallery-results"
+           hx-swap="innerHTML">
+      </div>
+      <div id="recipe-load-more-sentinel"></div>
+    </div>
+  </main>
+
+</div><!-- .content-area -->
 
 <script>
-  function closeDetail() {
-    window.location.href = document.querySelector('.detail-close').href;
-  }
-  document.querySelector('.detail-close').addEventListener('click', function (e) {
-    e.preventDefault();
-    closeDetail();
-  });
+  (function () {
+    const createBtn      = document.getElementById('create-recipes-btn');
+    const dropdown       = document.getElementById('create-recipes-dropdown');
+    const openModalBtns  = document.querySelectorAll('.open-import-modal-btn');
+    const overlay        = document.getElementById('import-overlay');
+    const form           = document.getElementById('import-form');
+    const modalTitle     = document.getElementById('import-modal-title');
+    const modalDesc      = overlay.querySelector('.import-modal__desc');
+    const closeModalBtn  = document.getElementById('close-import-modal-btn');
+    const fileInput      = document.getElementById('import-file-input');
+    const fileList       = document.getElementById('selected-files-list');
+    const submitBtn      = document.getElementById('import-submit-btn');
+
+    createBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      dropdown.hidden = !dropdown.hidden;
+    });
+
+    document.addEventListener('click', function () {
+      dropdown.hidden = true;
+    });
+
+    openModalBtns.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        form.setAttribute('hx-post', btn.dataset.importUrl);
+        htmx.process(form);
+        modalTitle.textContent = btn.dataset.importTitle;
+        modalDesc.textContent = btn.dataset.importDesc;
+        submitBtn.textContent = btn.dataset.importTitle;
+        dropdown.hidden = true;
+        overlay.hidden = false;
+        document.getElementById('import-result').innerHTML = '';
+        fileList.innerHTML = '';
+        fileList.hidden = true;
+        submitBtn.hidden = true;
+        fileInput.value = '';
+      });
+    });
+
+    function closeModal() {
+      overlay.hidden = true;
+    }
+
+    closeModalBtn.addEventListener('click', closeModal);
+
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) closeModal();
+    });
+
+    fileInput.addEventListener('change', function () {
+      fileList.innerHTML = '';
+      if (fileInput.files.length === 0) {
+        fileList.hidden = true;
+        submitBtn.hidden = true;
+        return;
+      }
+      Array.from(fileInput.files).forEach(function (file) {
+        const li = document.createElement('li');
+        li.textContent = file.name;
+        fileList.appendChild(li);
+      });
+      fileList.hidden = false;
+      submitBtn.hidden = false;
+    });
+  })();
+</script>
+
+<div id="recipe-detail-overlay">
+  {% include "recipes/partials/recipe_detail.html" %}
+</div>
+<div id="slot-overlay" hidden></div>
+
+<script>
+  window.closeRecipeDetail = function () {
+    document.getElementById('recipe-detail-overlay').hidden = true;
+    document.getElementById('slot-overlay').hidden = true;
+    var scroll = document.querySelector('.recipe-gallery-scroll');
+    if (scroll) scroll.style.overflow = '';
+    var params = new URLSearchParams(window.location.search);
+    history.replaceState(null, '', '/recipes/' + (params.toString() ? '?' + params.toString() : ''));
+  };
 
   function closeSlotOverlay() {
     document.getElementById('slot-overlay').hidden = true;
@@ -98,8 +736,21 @@
     }
   });
 
+  document.body.addEventListener('htmx:beforeHistoryUpdate', function (e) {
+    if (e.detail.target && e.detail.target.id === 'recipe-detail-overlay') {
+      var params = new URLSearchParams(window.location.search);
+      if (params.toString()) {
+        e.detail.history.path = e.detail.history.path + '?' + params.toString();
+      }
+    }
+  });
+
   document.body.addEventListener('htmx:afterSwap', function (e) {
-    if (e.detail.target.id === 'slot-overlay') {
+    if (e.detail.target.id === 'recipe-detail-overlay') {
+      e.detail.target.hidden = false;
+      var scroll = document.querySelector('.recipe-gallery-scroll');
+      if (scroll) scroll.style.overflow = 'hidden';
+    } else if (e.detail.target.id === 'slot-overlay') {
       e.detail.target.hidden = false;
     }
   });
@@ -109,11 +760,11 @@
   });
 
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape') {
-      var slotOverlay = document.getElementById('slot-overlay');
-      if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
-      closeDetail();
-    }
+    if (e.key !== 'Escape') return;
+    var slotOverlay = document.getElementById('slot-overlay');
+    if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
+    var detailOverlay = document.getElementById('recipe-detail-overlay');
+    if (detailOverlay && !detailOverlay.hidden) window.closeRecipeDetail();
   });
 </script>
 

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -733,7 +733,6 @@
 
 <script>
   // Recipe detail overlay logic.
-  var _explorerUrl = null;
 
   function closeSlotOverlay() {
     document.getElementById('slot-overlay').hidden = true;
@@ -743,10 +742,8 @@
     document.getElementById('recipe-detail-overlay').hidden = true;
     document.getElementById('slot-overlay').hidden = true;
     document.querySelector('.recipe-gallery-scroll').style.overflow = '';
-    if (_explorerUrl) {
-      history.replaceState(null, '', _explorerUrl);
-      _explorerUrl = null;
-    }
+    var params = new URLSearchParams(window.location.search);
+    history.replaceState(null, '', '/recipes/' + (params.toString() ? '?' + params.toString() : ''));
   }
 
   window._recipeDetailClose = closeRecipeDetail;
@@ -754,11 +751,16 @@
   var _slotSpinnerHTML = '<div class="slot-card slot-card--loading"><div class="slot-spinner"></div></div>';
   var _slotPushLoadingHTML = '<div class="slot-push-loading"><div class="slot-spinner-large"></div></div>';
 
-  document.body.addEventListener('htmx:beforeRequest', function (e) {
+  document.body.addEventListener('htmx:beforeHistoryUpdate', function (e) {
     if (e.detail.target && e.detail.target.id === 'recipe-detail-overlay') {
-      var detailOverlay = document.getElementById('recipe-detail-overlay');
-      if (detailOverlay.hidden) _explorerUrl = window.location.href;
+      var params = new URLSearchParams(window.location.search);
+      if (params.toString()) {
+        e.detail.history.path = e.detail.history.path + '?' + params.toString();
+      }
     }
+  });
+
+  document.body.addEventListener('htmx:beforeRequest', function (e) {
     if (e.detail.target && e.detail.target.id === 'slot-overlay') {
       var overlay = document.getElementById('slot-overlay');
       overlay.innerHTML = _slotSpinnerHTML;

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -786,6 +786,8 @@
 
   document.addEventListener('keydown', function (e) {
     if (e.key !== 'Escape') return;
+    var cardOverlay = document.getElementById('card-overlay');
+    if (cardOverlay && !cardOverlay.hidden) return;
     var slotOverlay = document.getElementById('slot-overlay');
     if (slotOverlay && !slotOverlay.hidden) { closeSlotOverlay(); return; }
     var detailOverlay = document.getElementById('recipe-detail-overlay');

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -1,5 +1,6 @@
 import json
 import mimetypes
+from urllib.parse import urlencode
 import attrs as _attrs
 import structlog
 from typing import Any
@@ -96,12 +97,20 @@ def image_detail_view(request: http.HttpRequest, image_id: int) -> http.HttpResp
             "max_rating": max_rating,
             "rating_range": rating_range,
         })
-    image = shortcuts.get_object_or_404(
-        models.Image.objects.select_related("fujifilm_recipe", "fujifilm_exif"),
-        pk=image_id,
-    )
+    active_filters = _active_filters_from_request(request)
+    rating_first = request.GET.get("rating_first", "1") == "1"
+    try:
+        detail = image_queries.get_image_detail(
+            image_id=image_id,
+            active_filters=active_filters,
+            rating_first=rating_first,
+        )
+    except models.Image.DoesNotExist:
+        raise http.Http404
     return shortcuts.render(request, "images/image_detail.html", {
-        "image": image,
+        "image": detail.image,
+        "prev_id": detail.prev_id,
+        "next_id": detail.next_id,
         "max_rating": max_rating,
         "rating_range": rating_range,
     })
@@ -776,6 +785,9 @@ class CreateRecipe(generic.FormView):  # type: ignore[type-arg]  # django_stubs_
             form.add_error(None, "An unexpected error occurred creating the recipe.")
             return self.render_to_response(self.get_context_data(form=form))
 
-        return shortcuts.redirect("recipe-detail", recipe_id=recipe.pk)
+        redirect_url = shortcuts.resolve_url("recipe-detail", recipe_id=recipe.pk)
+        if recipe.name:
+            redirect_url += "?" + urlencode({"name_search": recipe.name})
+        return shortcuts.redirect(redirect_url)
 
 

--- a/tests/functional/test_create_recipe_view.py
+++ b/tests/functional/test_create_recipe_view.py
@@ -193,7 +193,7 @@ class TestCreateRecipeViewSubmission:
         response = client.post(_URL, _valid_data())
         recipe = models.FujifilmRecipe.objects.get()
         assert response.status_code == 302
-        assert response["Location"] == f"/recipes/{recipe.pk}/"
+        assert response["Location"] == f"/recipes/{recipe.pk}/?name_search=My+Recipe"
 
     def test_duplicate_settings_show_already_exists_error(self, client) -> None:
         client.post(_URL, _valid_data(name="First"))


### PR DESCRIPTION
## Summary

- **Stateful navigation via shared skeleton**: Detail pages (`/recipes/{id}/`, `/images/{id}/`) now render the full explorer/gallery skeleton with the overlay pre-opened, then fire a background HTMX request to load the filtered list behind it. Filter state is encoded in the detail URL query params (e.g. `/recipes/123/?film_simulation=Astia`), so reloading the page preserves context and the close button always knows where to return.
-- **`_explorerUrl` / `_galleryUrl` variables removed**: The close handlers now derive the return URL from `URLSearchParams(window.location.search)` — the URL is always the source of truth.
-- **`htmx:beforeHistoryUpdate` on card click**: Filter params are appended to the URL HTMX pushes when opening a detail overlay, so clicking a recipe/image card from a filtered view produces the correct stateful URL.
-- **`CreateRecipe` redirect carries `name_search`**: After creating a recipe the redirect goes to `/recipes/{id}/?name_search={name}`, so the background explorer pre-filters to the new recipe.
-- **`image_detail_view` non-HTMX path**: Now computes active filters and calls `get_image_detail()` the same way as the HTMX path, so `prev_id` / `next_id` are available on direct URL access.
- **Fix: full-size image not loading on direct URL access**: Added a `DOMContentLoaded` handler that runs the same full-size upgrade logic as `htmx:afterSwap` for the server-rendered overlay case.
- **Fix: Escape key closing recipe detail behind recipe card modal**: Added a `#card-overlay` guard at the top of both Escape handlers so the first press closes only the card modal, not the recipe detail underneath.
