### PR TITLE
Add multi-select mode to recipe explorer and image gallery

### DIFF
--- a/src/interfaces/static/js/multi-select.js
+++ b/src/interfaces/static/js/multi-select.js
@@ -1,0 +1,154 @@
+// Inject shared toolbar styles once so they're available in any template that
+// includes this script, without duplicating CSS across templates.
+(function () {
+  if (document.getElementById('ms-controller-styles')) return;
+  var s = document.createElement('style');
+  s.id = 'ms-controller-styles';
+  s.textContent = `
+    .ms-toolbar { display: flex; align-items: center; gap: .5rem; }
+    .ms-toolbar[hidden] { display: none; }
+    .ms-count { font-size: .85rem; font-weight: 600; color: #444; min-width: 5rem; }
+    .ms-cancel-btn { padding: .4rem .85rem; background: none; border: 1px solid #ccc; border-radius: 5px; font-size: .85rem; font-weight: 600; color: #555; cursor: pointer; }
+    .ms-cancel-btn:hover { background: #f0f0f0; color: #333; }
+    .ms-actions-wrap { position: relative; }
+    .ms-actions-btn { display: inline-flex; align-items: center; gap: .35rem; padding: .4rem .85rem; background: var(--color-accent); color: #fff; border: none; border-radius: 5px; font-size: .85rem; font-weight: 600; cursor: pointer; white-space: nowrap; }
+    .ms-actions-btn:hover { background: var(--color-accent-dark); }
+    .ms-actions-dropdown { position: absolute; top: calc(100% + 6px); left: 0; min-width: 180px; background: #fff; border: 1px solid #ddd; border-radius: 6px; box-shadow: 0 4px 16px rgba(0,0,0,.12); z-index: 100; overflow: hidden; }
+    .ms-actions-dropdown[hidden] { display: none; }
+    .ms-actions-empty { display: block; padding: .65rem 1rem; font-size: .875rem; color: #aaa; font-style: italic; }
+  `;
+  document.head.appendChild(s);
+}());
+
+class MultiSelectController {
+  constructor({ containerSelector, cardSelector, pkAttr = 'data-pk', toolbarSelector = null, onSelectionChange = null }) {
+    this._containerSelector = containerSelector;
+    this._toolbarSelector = toolbarSelector;
+    this.cardSelector = cardSelector;
+    this.pkAttr = pkAttr;
+    this.onSelectionChange = onSelectionChange;
+    this.selectedPks = new Set();
+    this.active = false;
+
+    if (!document.querySelector(containerSelector)) return;
+    this._init();
+  }
+
+  _init() {
+    // Capture phase at document.body: survives HTMX history restorations that
+    // replace the container element with a fresh DOM node.
+    document.body.addEventListener('click', (evt) => {
+      const container = document.querySelector(this._containerSelector);
+      if (!container) return;
+
+      const card = evt.target.closest(this.cardSelector);
+      if (!card || !container.contains(card)) return;
+
+      const pk = card.getAttribute(this.pkAttr);
+      if (!pk) return;
+
+      const onCheckbox = !!evt.target.closest('.ms-checkbox');
+
+      if (onCheckbox || this.active) {
+        // stopPropagation: prevents HTMX listeners on child elements (e.g. <a hx-get>).
+        // preventDefault: prevents browser native anchor navigation.
+        evt.stopPropagation();
+        evt.preventDefault();
+        this._toggle(pk, card, container);
+      }
+    }, true);
+
+    // Cancel button inside the toolbar.
+    document.body.addEventListener('click', (evt) => {
+      if (!this._toolbarSelector) return;
+      const btn = evt.target.closest('.ms-cancel-btn');
+      if (!btn) return;
+      const toolbar = document.querySelector(this._toolbarSelector);
+      if (toolbar && toolbar.contains(btn)) this.clearSelection();
+    });
+
+    // Escape cancels multi-select (only when active, so it doesn't interfere
+    // with overlay-close handlers when multi-select is idle).
+    document.addEventListener('keydown', (evt) => {
+      if (evt.key === 'Escape' && this.active) this.clearSelection();
+    });
+
+    // Belt-and-suspenders: cancel any HTMX request from a card while active.
+    document.body.addEventListener('htmx:beforeRequest', (evt) => {
+      const container = document.querySelector(this._containerSelector);
+      if (!container) return;
+      if (this.active && container.contains(evt.detail.elt)) {
+        evt.preventDefault();
+      }
+    });
+
+    // Reset selection when a filter response replaces the container's contents.
+    document.body.addEventListener('htmx:afterSwap', (evt) => {
+      const container = document.querySelector(this._containerSelector);
+      if (evt.detail.target === container) this._resetState();
+    });
+
+    // HTMX history restoration replaces the DOM; internal state is now stale.
+    document.body.addEventListener('htmx:historyRestore', () => this._resetState());
+  }
+
+  _toggle(pk, card, container) {
+    if (this.selectedPks.has(pk)) {
+      this.selectedPks.delete(pk);
+      card.classList.remove('ms-selected');
+    } else {
+      this.selectedPks.add(pk);
+      card.classList.add('ms-selected');
+    }
+
+    this.active = this.selectedPks.size > 0;
+    container.classList.toggle('ms-active', this.active);
+    this._updateToolbar();
+    this._dispatch(container);
+  }
+
+  _resetState() {
+    this.selectedPks.clear();
+    this.active = false;
+    const container = document.querySelector(this._containerSelector);
+    if (container) {
+      container.classList.remove('ms-active');
+      container.querySelectorAll(`${this.cardSelector}.ms-selected`).forEach(card => {
+        card.classList.remove('ms-selected');
+      });
+    }
+    this._updateToolbar();
+    this._dispatch(container);
+  }
+
+  _updateToolbar() {
+    if (!this._toolbarSelector) return;
+    const toolbar = document.querySelector(this._toolbarSelector);
+    if (!toolbar) return;
+    toolbar.hidden = !this.active;
+    const countEl = toolbar.querySelector('.ms-count');
+    if (countEl) {
+      const n = this.selectedPks.size;
+      countEl.textContent = `${n} selected`;
+    }
+  }
+
+  _dispatch(container) {
+    const pks = Array.from(this.selectedPks);
+    if (container) {
+      container.dispatchEvent(new CustomEvent('multiselect:change', {
+        bubbles: true,
+        detail: { pks },
+      }));
+    }
+    if (this.onSelectionChange) this.onSelectionChange(pks);
+  }
+
+  getSelectedPks() {
+    return Array.from(this.selectedPks);
+  }
+
+  clearSelection() {
+    this._resetState();
+  }
+}

--- a/src/interfaces/templates/images/_gallery_results.html
+++ b/src/interfaces/templates/images/_gallery_results.html
@@ -1,6 +1,11 @@
 {% load image_filters %}
 {% for image in page_obj %}
-  <article class="image-card">
+  <article class="image-card" data-pk="{{ image.id }}">
+    <div class="ms-checkbox" aria-label="Select image">
+      <svg class="ms-check" width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true">
+        <polyline points="1,4 3.5,6.5 9,1" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </div>
     <a class="detail-link" href="{% url 'image-detail' image.id %}"
        hx-get="{% url 'image-detail' image.id %}"
        hx-target="#detail-overlay"

--- a/src/interfaces/templates/images/gallery.html
+++ b/src/interfaces/templates/images/gallery.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Image Gallery</title>
   <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  <script src="/static/js/multi-select.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/tom-select@2/dist/css/tom-select.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2/dist/js/tom-select.complete.min.js"></script>
   <link rel="stylesheet" href="/static/css/brand.css">
@@ -306,6 +307,68 @@
       font-style: italic;
     }
 
+    .gallery-header {
+      display: flex;
+      align-items: center;
+      padding: 1rem 2rem;
+      flex-shrink: 0;
+      min-height: 4rem;
+    }
+
+    /* ── Multi-select ────────────────────────────────────────────────── */
+    .image-card {
+      position: relative;
+    }
+
+    .image-card .ms-checkbox {
+      position: absolute;
+      top: 0.6rem;
+      left: 0.6rem;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: #fff;
+      border: 2px solid #bbb;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.12s, background 0.12s, border-color 0.12s;
+      cursor: pointer;
+      z-index: 2;
+    }
+
+    .image-card:hover .ms-checkbox,
+    #gallery-results.ms-active .image-card .ms-checkbox {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .image-card .ms-checkbox:hover {
+      border-color: var(--color-accent);
+      background: var(--color-accent-light);
+    }
+
+    .image-card .ms-check {
+      opacity: 0;
+      transition: opacity 0.12s;
+    }
+
+    .image-card.ms-selected .ms-checkbox {
+      background: var(--color-accent);
+      border-color: var(--color-accent);
+    }
+
+    .image-card.ms-selected .ms-check {
+      opacity: 1;
+    }
+
+    .image-card.ms-selected {
+      outline: 3px solid var(--color-accent);
+      outline-offset: -3px;
+    }
+
     #detail-overlay {
       position: fixed;
       inset: 0;
@@ -470,7 +533,24 @@
 </aside>
 
 <main class="main">
-  <div class="gallery-scroll" style="padding-top: 1.5rem;">
+  <div class="gallery-header">
+    <div class="ms-toolbar" id="ms-toolbar" hidden>
+      <span class="ms-count">0 selected</span>
+      <button class="ms-cancel-btn" type="button">Cancel</button>
+      <div class="ms-actions-wrap">
+        <button class="ms-actions-btn" id="ms-actions-btn" type="button">
+          Actions
+          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+            <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
+          <span class="ms-actions-empty">No actions available yet</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="gallery-scroll">
     <div id="gallery-results">
       {% include "images/_gallery_results.html" %}
     </div>
@@ -490,6 +570,26 @@
 </main>
 
 </div><!-- .content-area -->
+
+<script>
+  const imageMultiSelect = new MultiSelectController({
+    containerSelector: '#gallery-results',
+    cardSelector: '.image-card',
+    toolbarSelector: '#ms-toolbar',
+  });
+
+  (function () {
+    var actionsBtn = document.getElementById('ms-actions-btn');
+    var actionsDropdown = document.getElementById('ms-actions-dropdown');
+    actionsBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      actionsDropdown.hidden = !actionsDropdown.hidden;
+    });
+    document.addEventListener('click', function () {
+      actionsDropdown.hidden = true;
+    });
+  }());
+</script>
 
 <div id="detail-overlay" hidden></div>
 <div id="slot-overlay" hidden></div>

--- a/src/interfaces/templates/images/image_detail.html
+++ b/src/interfaces/templates/images/image_detail.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ image.filename }}</title>
   <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  <script src="/static/js/multi-select.js"></script>
   <link href="https://cdn.jsdelivr.net/npm/tom-select@2/dist/css/tom-select.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/tom-select@2/dist/js/tom-select.complete.min.js"></script>
   <link rel="stylesheet" href="/static/css/brand.css">
@@ -268,6 +269,68 @@
       font-style: italic;
     }
 
+    .gallery-header {
+      display: flex;
+      align-items: center;
+      padding: 1rem 2rem;
+      flex-shrink: 0;
+      min-height: 4rem;
+    }
+
+    /* ── Multi-select ────────────────────────────────────────────────── */
+    .image-card {
+      position: relative;
+    }
+
+    .image-card .ms-checkbox {
+      position: absolute;
+      top: 0.6rem;
+      left: 0.6rem;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: #fff;
+      border: 2px solid #bbb;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.12s, background 0.12s, border-color 0.12s;
+      cursor: pointer;
+      z-index: 2;
+    }
+
+    .image-card:hover .ms-checkbox,
+    #gallery-results.ms-active .image-card .ms-checkbox {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .image-card .ms-checkbox:hover {
+      border-color: var(--color-accent);
+      background: var(--color-accent-light);
+    }
+
+    .image-card .ms-check {
+      opacity: 0;
+      transition: opacity 0.12s;
+    }
+
+    .image-card.ms-selected .ms-checkbox {
+      background: var(--color-accent);
+      border-color: var(--color-accent);
+    }
+
+    .image-card.ms-selected .ms-check {
+      opacity: 1;
+    }
+
+    .image-card.ms-selected {
+      outline: 3px solid var(--color-accent);
+      outline-offset: -3px;
+    }
+
     #detail-overlay {
       position: fixed;
       inset: 0;
@@ -422,7 +485,24 @@
 </aside>
 
 <main class="main">
-  <div class="gallery-scroll" style="padding-top: 1.5rem;">
+  <div class="gallery-header">
+    <div class="ms-toolbar" id="ms-toolbar" hidden>
+      <span class="ms-count">0 selected</span>
+      <button class="ms-cancel-btn" type="button">Cancel</button>
+      <div class="ms-actions-wrap">
+        <button class="ms-actions-btn" id="ms-actions-btn" type="button">
+          Actions
+          <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+            <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
+          <span class="ms-actions-empty">No actions available yet</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="gallery-scroll">
     <div id="gallery-results"
          hx-get="{% url 'gallery' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}"
          hx-trigger="load"
@@ -501,6 +581,24 @@
       initRecipeSelects();
     }
   });
+
+  const imageMultiSelect = new MultiSelectController({
+    containerSelector: '#gallery-results',
+    cardSelector: '.image-card',
+    toolbarSelector: '#ms-toolbar',
+  });
+
+  (function () {
+    var actionsBtn = document.getElementById('ms-actions-btn');
+    var actionsDropdown = document.getElementById('ms-actions-dropdown');
+    actionsBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      actionsDropdown.hidden = !actionsDropdown.hidden;
+    });
+    document.addEventListener('click', function () {
+      actionsDropdown.hidden = true;
+    });
+  }());
 
   document.body.addEventListener('htmx:afterSwap', function (e) {
     if (e.detail.target.id !== 'detail-overlay') return;

--- a/src/interfaces/templates/recipes/includes/recipe_results.html
+++ b/src/interfaces/templates/recipes/includes/recipe_results.html
@@ -1,9 +1,15 @@
 {% for recipe in page_obj.items %}
 <article class="recipe-card"
+         data-pk="{{ recipe.id }}"
          style="{% if recipe.cover_image_id %}background-image: url('/images/file/{{ recipe.cover_image_id }}/?width=600');{% endif %} cursor: pointer;"
          hx-get="{% url 'recipe-detail' recipe.id %}"
          hx-target="#recipe-detail-overlay"
          hx-push-url="{% url 'recipe-detail' recipe.id %}">
+  <div class="ms-checkbox" aria-label="Select recipe">
+    <svg class="ms-check" width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true">
+      <polyline points="1,4 3.5,6.5 9,1" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </div>
   <div class="recipe-card__overlay">
     <div class="recipe-card__bottom">
       {% if recipe.film_sim_logo_filename %}

--- a/src/interfaces/templates/recipes/recipes_explorer.html
+++ b/src/interfaces/templates/recipes/recipes_explorer.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Recipes</title>
   <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+  <script src="/static/js/multi-select.js"></script>
   <link rel="stylesheet" href="/static/css/brand.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -182,9 +183,9 @@
     .gallery-header {
       display: flex;
       align-items: center;
-      justify-content: flex-end;
       padding: 1rem 2rem;
       flex-shrink: 0;
+      min-height: 4rem;
     }
 
     .recipe-gallery-scroll {
@@ -263,6 +264,61 @@
       grid-column: 1 / -1;
       color: #888;
       font-style: italic;
+    }
+
+    /* ── Multi-select ────────────────────────────────────────────────── */
+    .recipe-card .ms-checkbox {
+      position: absolute;
+      top: 0.6rem;
+      left: 0.6rem;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.35);
+      border: 2px solid rgba(255, 255, 255, 0.65);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.12s, background 0.12s, border-color 0.12s;
+      cursor: pointer;
+      z-index: 2;
+    }
+
+    .recipe-card:hover .ms-checkbox,
+    #recipe-gallery-results.ms-active .ms-checkbox {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .recipe-card .ms-checkbox:hover {
+      border-color: var(--color-accent);
+      background: rgba(239, 68, 68, 0.35);
+    }
+
+    .recipe-card .ms-check {
+      opacity: 0;
+      transition: opacity 0.12s;
+    }
+
+    .recipe-card.ms-selected .ms-checkbox {
+      background: var(--color-accent);
+      border-color: var(--color-accent);
+    }
+
+    .recipe-card.ms-selected .ms-check {
+      opacity: 1;
+    }
+
+    .recipe-card.ms-selected::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border: 3px solid var(--color-accent);
+      border-radius: 8px;
+      pointer-events: none;
+      z-index: 1;
     }
 
     /* ── Header action buttons ───────────────────────────────────────── */
@@ -558,6 +614,21 @@
 
   <main class="main">
     <div class="gallery-header">
+      <div class="ms-toolbar" id="ms-toolbar" hidden>
+        <span class="ms-count">0 selected</span>
+        <button class="ms-cancel-btn" type="button">Cancel</button>
+        <div class="ms-actions-wrap">
+          <button class="ms-actions-btn" id="ms-actions-btn" type="button">
+            Actions
+            <svg width="10" height="6" viewBox="0 0 10 6" fill="none" aria-hidden="true">
+              <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
+          <div class="ms-actions-dropdown" id="ms-actions-dropdown" hidden>
+            <span class="ms-actions-empty">No actions available yet</span>
+          </div>
+        </div>
+      </div>
       <div class="header-actions">
         <a href="{% url 'create-recipe' %}" class="create-recipe-link-btn">
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -726,6 +797,26 @@
       submitBtn.hidden = false;
     });
   })();
+</script>
+
+<script>
+  const recipeMultiSelect = new MultiSelectController({
+    containerSelector: '#recipe-gallery-results',
+    cardSelector: '.recipe-card',
+    toolbarSelector: '#ms-toolbar',
+  });
+
+  (function () {
+    var actionsBtn = document.getElementById('ms-actions-btn');
+    var actionsDropdown = document.getElementById('ms-actions-dropdown');
+    actionsBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      actionsDropdown.hidden = !actionsDropdown.hidden;
+    });
+    document.addEventListener('click', function () {
+      actionsDropdown.hidden = true;
+    });
+  }());
 </script>
 
 <div id="recipe-detail-overlay" hidden></div>


### PR DESCRIPTION
## Summary

- Add reusable `MultiSelectController` JS class (`multi-select.js`) that works across any card-based gallery
- Hovering a card reveals a checkbox in the top-left corner; clicking it enters multi-select mode
- In multi-select mode, clicking anywhere on a card toggles its selection; Escape or Cancel exits
- Selected cards are visually highlighted with a red border indicator
- A toolbar (count, Cancel, Actions) appears in the gallery header only when ≥ 1 item is selected
- Actions button shows a placeholder dropdown for future batch operations
- Multi-select works on both the recipe explorer and image gallery, including direct URL access to image detail pages

## Technical notes

- Controller attaches listeners on `document.body` in capture phase so it survives HTMX history restorations that replace the container DOM node
- Container is re-queried on every event (not cached at init time) for the same reason
- `htmx:beforeRequest` cancellation as belt-and-suspenders to prevent HTMX requests from card clicks while active
- Selection resets on `htmx:afterSwap` (filter change) and `htmx:historyRestore` (back navigation)
- Recipe cards use a `::after` pseudo-element border (stays inside card bounds); image cards use `outline` with `outline-offset: -3px` (not clipped by `overflow: auto` on the scroll container)
- Shared toolbar CSS is injected once from `multi-select.js`; card-specific styles remain in each template

