### PR TITLE
Notify user when there are updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,14 @@ update:
 
 ## run         — start the Django development server
 run:
-	$(PYTHON) manage.py runserver
+	@git fetch origin main --quiet 2>/dev/null; \
+	BEHIND=$$(git rev-list --count main..origin/main 2>/dev/null); \
+	if [ "$$BEHIND" -gt 0 ] 2>/dev/null; then \
+		printf '\n\033[1;33m[update] %s new commit(s) available. Run '"'"'make update'"'"' to get the latest changes.\033[0m\n\n' "$$BEHIND"; \
+	else \
+		printf '\n\033[1;32mYou are on the latest version.\033[0m\n\n'; \
+	fi
+	@$(PYTHON) manage.py runserver
 
 ## worker      — start a Celery worker (full stack only; requires RabbitMQ)
 worker:


### PR DESCRIPTION
## Summary

- Added an update check to `make run` that fetches `origin/main` and compares it with the local `main` branch
- Prints a bold yellow notice with the number of new commits if updates are available
- Prints a bold green confirmation if already on the latest version
- Network errors are suppressed, so the check fails silently when offline
