### PR TITLE
Redesign recipe detail view with light theme and sectioned layout

### DIFF
--- a/src/interfaces/templates/recipes/_recipe_name_prompt.html
+++ b/src/interfaces/templates/recipes/_recipe_name_prompt.html
@@ -16,7 +16,7 @@
          onkeydown="if(event.key==='Escape'){event.stopPropagation();var p=this.closest('form');p.querySelector('.recipe-name-form-state').style.display='none';p.querySelector('.recipe-title-input').style.display='none';p.querySelector('.recipe-title-display').style.display='';p.querySelector('.recipe-name-btn-state').style.display='flex';}"
          {% if show_form %} autofocus{% else %} style="display:none"{% endif %}>
 
-  {# "Edit recipe name" button — hidden while editing #}
+  {# Rename button — hidden while editing #}
   <div class="recipe-name-btn-state"{% if show_form %} style="display:none"{% endif %}>
     <button type="button" class="name-recipe-btn"
             onclick="var p=this.closest('form');
@@ -25,7 +25,11 @@
                      p.querySelector('.recipe-name-btn-state').style.display='none';
                      p.querySelector('.recipe-name-form-state').style.display='flex';
                      p.querySelector('.recipe-title-input').focus();">
-      Edit recipe name
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+      </svg>
+      Rename
     </button>
   </div>
 

--- a/src/interfaces/templates/recipes/partials/recipe_detail.html
+++ b/src/interfaces/templates/recipes/partials/recipe_detail.html
@@ -5,7 +5,7 @@
     flex-direction: column;
     height: 100%;
     font-family: sans-serif;
-    background: #1a1a1a;
+    background: var(--color-bg-page);
   }
 
   .detail-header {
@@ -13,9 +13,9 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.75rem 1.5rem;
-    background: #000;
+    background: var(--color-bg-surface);
     flex-shrink: 0;
-    border-bottom: 1px solid #2a2a2a;
+    border-bottom: 1px solid var(--color-border);
   }
 
   .header-logo {
@@ -33,8 +33,8 @@
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 50%;
-    background: rgba(255,255,255,0.12);
-    color: #fff;
+    background: rgba(0,0,0,0.07);
+    color: var(--color-text-primary);
     font-size: 1.25rem;
     text-decoration: none;
     transition: background 0.15s;
@@ -42,7 +42,7 @@
     cursor: pointer;
   }
 
-  .detail-close:hover { background: rgba(255,255,255,0.25); }
+  .detail-close:hover { background: rgba(0,0,0,0.14); }
 
   /* Name prompt in header — title and input share the same slot */
   .recipe-name-prompt {
@@ -58,7 +58,7 @@
   .recipe-title-display {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #ddd;
+    color: var(--color-text-primary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -69,10 +69,10 @@
   .recipe-title-input {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #ddd;
+    color: var(--color-text-primary);
     background: transparent;
     border: none;
-    border-bottom: 1px solid #555;
+    border-bottom: 1px solid var(--color-border);
     outline: none;
     width: 22ch;
     flex-shrink: 0;
@@ -99,24 +99,25 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
-    justify-content: center;
   }
 
   /* Left: recipe settings */
   .detail-settings-col {
-    flex: 0 1 520px;
-    overflow-y: auto;
-    padding: 2rem 1.5rem;
-    color: #ddd;
+    flex: 1;
+    overflow-y: hidden;
+    padding: 2rem 2.5rem;
+    color: var(--color-text-primary);
+    background: #f8f9fa;
   }
 
   /* Right: actions */
   .detail-actions-col {
-    flex: 0 1 340px;
+    flex: 0 0 420px;
     overflow-y: auto;
-    padding: 2rem 1.5rem;
-    color: #ddd;
-    border-left: 1px solid #2a2a2a;
+    padding: 2.5rem 2.5rem;
+    color: var(--color-text-primary);
+    border-left: 1px solid var(--color-border);
+    background: var(--color-bg-surface);
   }
 
   .detail-section-title {
@@ -124,10 +125,10 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #555;
+    color: #6b7280;
     margin-bottom: 1rem;
-    padding-bottom: 0.4rem;
-    border-bottom: 1px solid #2a2a2a;
+    padding-left: 0.65rem;
+    border-left: 3px solid var(--color-accent);
   }
 
   /* Single-field row */
@@ -161,7 +162,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: #555;
+    color: #9ca3af;
     margin-bottom: 0.2rem;
   }
 
@@ -174,7 +175,8 @@
 
   .detail-value {
     font-size: 0.95rem;
-    color: #ddd;
+    font-weight: 500;
+    color: var(--color-text-primary);
     padding-left: calc(13px + 6px); /* align with label text, past the icon */
   }
 
@@ -182,15 +184,15 @@
   .action-group {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 0.6rem;
   }
 
   .action-btn {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.45rem 1.1rem;
+    padding: 0.5rem 1rem;
     font-size: 0.85rem;
     font-weight: 600;
     border-radius: 6px;
@@ -198,6 +200,9 @@
     border: none;
     transition: background 0.15s, color 0.15s;
     white-space: nowrap;
+    text-align: center;
+    width: 100%;
+    max-width: 240px;
   }
 
   .action-btn--primary {
@@ -208,37 +213,39 @@
   .action-btn--primary:hover { background: var(--color-accent-dark); }
 
   .action-btn--secondary {
-    background: transparent;
-    color: #aaa;
-    border: 1px solid #444;
+    background: #fff;
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-border);
     text-decoration: none;
   }
 
-  .action-btn--secondary:hover { border-color: #aaa; color: #ddd; }
+  .action-btn--secondary:hover { border-color: #bbb; background: #f5f5f5; }
 
   .action-btn--disabled {
     background: transparent;
-    color: #444;
-    border: 1px solid #333;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
     cursor: not-allowed;
+    opacity: 0.6;
   }
 
   .action-hint {
     font-size: 0.75rem;
-    color: #444;
+    color: var(--color-text-muted);
   }
 
-  /* Edit recipe name button + form */
+  /* Rename button + form */
   .name-recipe-btn {
     display: inline-flex;
     align-items: center;
+    gap: 0.3rem;
     justify-content: center;
     padding: 0.3rem 0.75rem;
     font-size: 0.72rem;
     font-weight: 600;
     background: transparent;
-    color: #666;
-    border: 1px solid #3a3a3a;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
     border-radius: 4px;
     cursor: pointer;
     transition: border-color 0.15s, color 0.15s;
@@ -249,8 +256,8 @@
   }
 
   .name-recipe-btn:hover {
-    border-color: #777;
-    color: #ccc;
+    border-color: #bbb;
+    color: var(--color-text-primary);
   }
 
   .recipe-name-ok-btn {
@@ -269,9 +276,9 @@
     padding: 0.4rem 0.7rem;
     font-size: 0.8rem;
     font-weight: 600;
-    color: #888;
+    color: var(--color-text-muted);
     background: transparent;
-    border: 1px solid #555;
+    border: 1px solid var(--color-border);
     border-radius: 4px;
     cursor: pointer;
     white-space: nowrap;
@@ -284,10 +291,131 @@
     margin-bottom: 0.2rem;
   }
 
+  .detail-fields {
+    padding-top: 1.25rem;
+  }
+
+  /* Sectioned settings layout */
+  .settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 2.5rem;
+  }
+
+  .settings-bottom {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 2.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .settings-section {
+    margin-bottom: 1.75rem;
+  }
+
+  .settings-section-header {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #4b5563;
+    margin-bottom: 0.5rem;
+  }
+
+  .settings-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4rem 0 0.4rem 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    gap: 0.75rem;
+  }
+
+  .settings-row-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9ca3af;
+    flex-shrink: 0;
+  }
+
+  .settings-row-value {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    text-align: right;
+  }
+
+  /* WB color grid (read-only) */
+  .wb-grid-readonly-outer {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+  }
+
+  .wb-grid-readonly-legend {
+    font-size: 1rem;
+    font-weight: 700;
+    font-family: monospace;
+    letter-spacing: 0.06em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    white-space: nowrap;
+  }
+
+  .wb-legend-r { color: var(--color-accent); }
+  .wb-legend-b { color: #2563eb; }
+
+  .wb-grid-readonly-wrap {
+    display: grid;
+    grid-template-columns: repeat(19, 10px);
+    grid-template-rows: repeat(19, 10px);
+    gap: 2px;
+    line-height: 0;
+  }
+
+  .wb-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+  }
+
+  .wb-dot--selected {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px var(--color-accent);
+    position: relative;
+    z-index: 1;
+    transform: scale(1.35);
+  }
+
   .detail-image-count {
     font-size: 0.8rem;
-    color: #444;
+    color: var(--color-text-muted);
     margin-top: 1.5rem;
+  }
+
+  /* Distribution placeholder */
+  .detail-distribution {
+    margin-top: 2rem;
+  }
+
+  .detail-distribution-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 120px;
+    border: 1px dashed var(--color-border);
+    border-radius: 6px;
+    color: var(--color-text-muted);
+    font-size: 0.78rem;
+    text-align: center;
+    padding: 1rem;
   }
 </style>
 
@@ -307,256 +435,295 @@
     <div class="detail-settings-col">
       <h2 class="detail-section-title">Recipe settings</h2>
 
-      {# Film Simulation — film strip #}
-      <div class="detail-field">
-        <span class="detail-label">
-          <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
-            <rect x="1" y="2.5" width="12" height="9" rx="0.8"/>
-            <rect x="1.2" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
-            <rect x="1.2" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
-            <rect x="10.6" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
-            <rect x="10.6" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
-            <line x1="4.8" y1="2.5" x2="4.8" y2="11.5" stroke-width="0.7" opacity="0.45"/>
-            <line x1="9.2" y1="2.5" x2="9.2" y2="11.5" stroke-width="0.7" opacity="0.45"/>
-          </svg>
-          Film Simulation
-        </span>
-        <span class="detail-value">{{ recipe.film_simulation }}</span>
-      </div>
+      <div class="detail-fields">
 
-      {% if is_monochromatic %}
-        {# BW tone shifts — bidirectional horizontal / vertical arrows #}
-        <div class="detail-pair">
-          <div class="detail-field">
-            <span class="detail-label">
-              <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
-                <line x1="1" y1="7" x2="13" y2="7"/>
-                <polyline points="4,4.5 1,7 4,9.5"/>
-                <polyline points="10,4.5 13,7 10,9.5"/>
-              </svg>
-              BW Warm / Cool
-            </span>
-            <span class="detail-value">{{ recipe.monochromatic_color_warm_cool|signed }}</span>
+        <div class="settings-grid">
+
+          {# LEFT COLUMN: BASIC · GRAIN · WHITE BALANCE #}
+          <div>
+
+            <div class="settings-section">
+              <div class="settings-section-header">Basic</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M1.5 2.5 L8 2.5 L12.5 7 L8 11.5 L1.5 11.5 Z"/>
+                    <circle cx="4.5" cy="7" r="1" fill="currentColor" stroke="none"/>
+                  </svg>
+                  Name
+                </span>
+                <span class="settings-row-value">{{ recipe.name|default:"—" }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                    <rect x="1" y="2.5" width="12" height="9" rx="0.8"/>
+                    <rect x="1.2" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                    <rect x="1.2" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                    <rect x="10.6" y="4" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                    <rect x="10.6" y="8.2" width="2.2" height="1.8" rx="0.3" fill="currentColor" stroke="none"/>
+                    <line x1="4.8" y1="2.5" x2="4.8" y2="11.5" stroke-width="0.7" opacity="0.45"/>
+                    <line x1="9.2" y1="2.5" x2="9.2" y2="11.5" stroke-width="0.7" opacity="0.45"/>
+                  </svg>
+                  Film Simulation
+                </span>
+                <span class="settings-row-value">{{ recipe.film_simulation }}</span>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <div class="settings-section-header">Grain</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+                    <circle cx="3" cy="3.5" r="1.1"/>
+                    <circle cx="8.5" cy="2.5" r="1.1"/>
+                    <circle cx="12" cy="5.5" r="1.1"/>
+                    <circle cx="5.5" cy="7.5" r="1.1"/>
+                    <circle cx="11" cy="9.5" r="1.1"/>
+                    <circle cx="2.5" cy="11" r="1.1"/>
+                    <circle cx="7.5" cy="11.5" r="1.1"/>
+                  </svg>
+                  Grain Roughness
+                </span>
+                <span class="settings-row-value">{{ recipe.grain_roughness }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+                    <circle cx="4" cy="9" r="3.5"/>
+                    <circle cx="10.5" cy="5" r="1.8"/>
+                  </svg>
+                  Grain Size
+                </span>
+                <span class="settings-row-value">{{ recipe.grain_size }}</span>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <div class="settings-section-header">White Balance</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M5 9.5 C5 9.5 3.2 8.3 3.2 6.2 A3.8 3.8 0 0 1 10.8 6.2 C10.8 8.3 9 9.5 9 9.5 Z"/>
+                    <line x1="5.2" y1="11" x2="8.8" y2="11"/>
+                    <line x1="5.8" y1="12.5" x2="8.2" y2="12.5"/>
+                  </svg>
+                  White Balance
+                </span>
+                <span class="settings-row-value">{{ recipe.white_balance }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                    <line x1="2" y1="7" x2="11" y2="7"/>
+                    <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+                    <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">R</text>
+                  </svg>
+                  WB Red Shift
+                </span>
+                <span class="settings-row-value">{{ recipe.white_balance_red|signed }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                    <line x1="2" y1="7" x2="11" y2="7"/>
+                    <polyline points="8.5,4.5 11,7 8.5,9.5"/>
+                    <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">B</text>
+                  </svg>
+                  WB Blue Shift
+                </span>
+                <span class="settings-row-value">{{ recipe.white_balance_blue|signed }}</span>
+              </div>
+            </div>
+
+            {% if is_monochromatic %}
+            <div class="settings-section">
+              <div class="settings-section-header">BW Tone</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                    <line x1="1" y1="7" x2="13" y2="7"/>
+                    <polyline points="4,4.5 1,7 4,9.5"/>
+                    <polyline points="10,4.5 13,7 10,9.5"/>
+                  </svg>
+                  BW Warm / Cool
+                </span>
+                <span class="settings-row-value">{{ recipe.monochromatic_color_warm_cool|signed }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+                    <line x1="7" y1="1" x2="7" y2="13"/>
+                    <polyline points="4.5,4 7,1 9.5,4"/>
+                    <polyline points="4.5,10 7,13 9.5,10"/>
+                  </svg>
+                  BW Magenta / Green
+                </span>
+                <span class="settings-row-value">{{ recipe.monochromatic_color_magenta_green|signed }}</span>
+              </div>
+            </div>
+            {% endif %}
+
+          </div>{# /left column #}
+
+          {# RIGHT COLUMN: DYNAMIC RANGE · COLOR CHROME (or BW) · WB GRID #}
+          <div>
+
+            <div class="settings-section">
+              <div class="settings-section-header">Dynamic Range</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
+                    <rect x="1" y="9" width="2.5" height="4" rx="0.3"/>
+                    <rect x="4.5" y="6" width="2.5" height="7" rx="0.3"/>
+                    <rect x="8" y="3.5" width="2.5" height="9.5" rx="0.3"/>
+                    <rect x="11.5" y="6.5" width="1.5" height="6.5" rx="0.3"/>
+                  </svg>
+                  Dynamic Range
+                </span>
+                <span class="settings-row-value">{{ recipe.dynamic_range }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                    <line x1="1" y1="4" x2="13" y2="4"/>
+                    <line x1="1" y1="7" x2="10" y2="7"/>
+                    <line x1="1" y1="10" x2="7" y2="10"/>
+                  </svg>
+                  D-Range Priority
+                </span>
+                <span class="settings-row-value">{{ recipe.d_range_priority }}</span>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <div class="settings-section-header">Color Chrome</div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+                    <polygon points="7,1 13,12 1,12"/>
+                    <line x1="7" y1="1" x2="4" y2="7" stroke-width="0.8" opacity="0.5"/>
+                    <line x1="7" y1="1" x2="7.5" y2="5.5" stroke-width="0.8" opacity="0.5"/>
+                    <line x1="7" y1="1" x2="10.5" y2="8" stroke-width="0.8" opacity="0.5"/>
+                  </svg>
+                  Color Chrome Effect
+                </span>
+                <span class="settings-row-value">{{ recipe.color_chrome_effect }}</span>
+              </div>
+              <div class="settings-row">
+                <span class="settings-row-label">
+                  <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                    <circle cx="7" cy="7" r="5.5"/>
+                    <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" opacity="0.6"/>
+                  </svg>
+                  Color Chrome FX Blue
+                </span>
+                <span class="settings-row-value">{{ recipe.color_chrome_fx_blue }}</span>
+              </div>
+            </div>
+
+            <div class="settings-section">
+              <div class="wb-grid-readonly-outer">
+                <div class="wb-grid-readonly-wrap"
+                     data-r="{{ recipe.white_balance_red }}"
+                     data-b="{{ recipe.white_balance_blue }}"></div>
+                <div class="wb-grid-readonly-legend">
+                  <span class="wb-legend-r">R {{ recipe.white_balance_red|signed }}</span>
+                  <span class="wb-legend-b">B {{ recipe.white_balance_blue|signed }}</span>
+                </div>
+              </div>
+            </div>
+
+          </div>{# /right column #}
+
+        </div>{# /.settings-grid #}
+
+        {# BOTTOM: TONE & COLOR · DETAIL #}
+        <div class="settings-bottom">
+
+          <div class="settings-section">
+            <div class="settings-section-header">Tone &amp; Color</div>
+            <div class="settings-row">
+              <span class="settings-row-label">
+                <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
+                  <circle cx="7" cy="7" r="2.2"/>
+                  <line x1="7" y1="1" x2="7" y2="2"/>
+                  <line x1="7" y1="12" x2="7" y2="13"/>
+                  <line x1="1" y1="7" x2="2" y2="7"/>
+                  <line x1="12" y1="7" x2="13" y2="7"/>
+                  <line x1="2.8" y1="2.8" x2="3.5" y2="3.5"/>
+                  <line x1="10.5" y1="10.5" x2="11.2" y2="11.2"/>
+                  <line x1="11.2" y1="2.8" x2="10.5" y2="3.5"/>
+                  <line x1="3.5" y1="10.5" x2="2.8" y2="11.2"/>
+                </svg>
+                Highlight
+              </span>
+              <span class="settings-row-value">{{ recipe.highlight|signed }}</span>
+            </div>
+            <div class="settings-row">
+              <span class="settings-row-label">
+                <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                  <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z" fill="currentColor" opacity="0.55" stroke="none"/>
+                  <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z"/>
+                </svg>
+                Shadow
+              </span>
+              <span class="settings-row-value">{{ recipe.shadow|signed }}</span>
+            </div>
+            <div class="settings-row">
+              <span class="settings-row-label">
+                <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                  <circle cx="7" cy="7" r="5.5"/>
+                  <circle cx="5" cy="5.5" r="1.1" fill="currentColor" stroke="none"/>
+                  <circle cx="9" cy="5" r="1.1" fill="currentColor" stroke="none"/>
+                  <circle cx="10.2" cy="8.5" r="1.1" fill="currentColor" stroke="none"/>
+                  <circle cx="4.2" cy="9.2" r="1.1" fill="currentColor" stroke="none"/>
+                </svg>
+                Color
+              </span>
+              <span class="settings-row-value">{{ recipe.color|signed }}</span>
+            </div>
           </div>
-          <div class="detail-field">
-            <span class="detail-label">
-              <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
-                <line x1="7" y1="1" x2="7" y2="13"/>
-                <polyline points="4.5,4 7,1 9.5,4"/>
-                <polyline points="4.5,10 7,13 9.5,10"/>
-              </svg>
-              BW Magenta / Green
-            </span>
-            <span class="detail-value">{{ recipe.monochromatic_color_magenta_green|signed }}</span>
+
+          <div class="settings-section">
+            <div class="settings-section-header">Detail</div>
+            <div class="settings-row">
+              <span class="settings-row-label">
+                <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+                  <polygon points="7,1 13,7 7,13 1,7"/>
+                  <polygon points="7,3.5 10.5,7 7,10.5 3.5,7" fill="currentColor" opacity="0.25" stroke="none"/>
+                </svg>
+                Sharpness
+              </span>
+              <span class="settings-row-value">{{ recipe.sharpness|signed }}</span>
+            </div>
+            <div class="settings-row">
+              <span class="settings-row-label">
+                <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5 Z" fill="currentColor" opacity="0.2"/>
+                  <polyline points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5 Z"/>
+                </svg>
+                High ISO NR
+              </span>
+              <span class="settings-row-value">{{ recipe.high_iso_nr|signed }}</span>
+            </div>
+            <div class="settings-row">
+              <span class="settings-row-label">
+                <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
+                  <circle cx="7" cy="7" r="5.5"/>
+                  <circle cx="7" cy="7" r="3.2"/>
+                  <circle cx="7" cy="7" r="1" fill="currentColor" stroke="none"/>
+                </svg>
+                Clarity
+              </span>
+              <span class="settings-row-value">{{ recipe.clarity|signed }}</span>
+            </div>
           </div>
-        </div>
-      {% endif %}
 
-      {# Grain — scattered dots for roughness, varying sizes for grain size #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
-              <circle cx="3" cy="3.5" r="1.1"/>
-              <circle cx="8.5" cy="2.5" r="1.1"/>
-              <circle cx="12" cy="5.5" r="1.1"/>
-              <circle cx="5.5" cy="7.5" r="1.1"/>
-              <circle cx="11" cy="9.5" r="1.1"/>
-              <circle cx="2.5" cy="11" r="1.1"/>
-              <circle cx="7.5" cy="11.5" r="1.1"/>
-            </svg>
-            Grain Roughness
-          </span>
-          <span class="detail-value">{{ recipe.grain_roughness }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
-              <circle cx="4" cy="9" r="3.5"/>
-              <circle cx="10.5" cy="5" r="1.8"/>
-            </svg>
-            Grain Size
-          </span>
-          <span class="detail-value">{{ recipe.grain_size }}</span>
-        </div>
-      </div>
+        </div>{# /.settings-bottom #}
 
-      {# Color Chrome — prism for CCE, circle-with-dot for FX Blue #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
-              <polygon points="7,1 13,12 1,12"/>
-              <line x1="7" y1="1" x2="4" y2="7" stroke-width="0.8" opacity="0.5"/>
-              <line x1="7" y1="1" x2="7.5" y2="5.5" stroke-width="0.8" opacity="0.5"/>
-              <line x1="7" y1="1" x2="10.5" y2="8" stroke-width="0.8" opacity="0.5"/>
-            </svg>
-            Color Chrome Effect
-          </span>
-          <span class="detail-value">{{ recipe.color_chrome_effect }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
-              <circle cx="7" cy="7" r="5.5"/>
-              <circle cx="7" cy="7" r="2" fill="currentColor" stroke="none" opacity="0.6"/>
-            </svg>
-            Color Chrome FX Blue
-          </span>
-          <span class="detail-value">{{ recipe.color_chrome_fx_blue }}</span>
-        </div>
-      </div>
-
-      {# White Balance — lightbulb (colour temperature of the light source) #}
-      <div class="detail-field">
-        <span class="detail-label">
-          <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M5 9.5 C5 9.5 3.2 8.3 3.2 6.2 A3.8 3.8 0 0 1 10.8 6.2 C10.8 8.3 9 9.5 9 9.5 Z"/>
-            <line x1="5.2" y1="11" x2="8.8" y2="11"/>
-            <line x1="5.8" y1="12.5" x2="8.2" y2="12.5"/>
-          </svg>
-          White Balance
-        </span>
-        <span class="detail-value">{{ recipe.white_balance }}</span>
-      </div>
-
-      {# WB Shifts — warm thermometer (R) and cool thermometer (B) #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
-              <line x1="2" y1="7" x2="11" y2="7"/>
-              <polyline points="8.5,4.5 11,7 8.5,9.5"/>
-              <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">R</text>
-            </svg>
-            WB Red Shift
-          </span>
-          <span class="detail-value">{{ recipe.white_balance_red|signed }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
-              <line x1="2" y1="7" x2="11" y2="7"/>
-              <polyline points="8.5,4.5 11,7 8.5,9.5"/>
-              <text x="1" y="12" font-size="5" fill="currentColor" stroke="none" font-weight="700" font-family="sans-serif">B</text>
-            </svg>
-            WB Blue Shift
-          </span>
-          <span class="detail-value">{{ recipe.white_balance_blue|signed }}</span>
-        </div>
-      </div>
-
-      {# Dynamic Range — histogram bars / DR priority layered bars #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="currentColor">
-              <rect x="1" y="9" width="2.5" height="4" rx="0.3"/>
-              <rect x="4.5" y="6" width="2.5" height="7" rx="0.3"/>
-              <rect x="8" y="3.5" width="2.5" height="9.5" rx="0.3"/>
-              <rect x="11.5" y="6.5" width="1.5" height="6.5" rx="0.3"/>
-            </svg>
-            Dynamic Range
-          </span>
-          <span class="detail-value">{{ recipe.dynamic_range }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
-              <line x1="1" y1="4" x2="13" y2="4"/>
-              <line x1="1" y1="7" x2="10" y2="7"/>
-              <line x1="1" y1="10" x2="7" y2="10"/>
-            </svg>
-            D-Range Priority
-          </span>
-          <span class="detail-value">{{ recipe.d_range_priority }}</span>
-        </div>
-      </div>
-
-      {# Tone curve — Highlight (sun) / Shadow (moon) #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round">
-              <circle cx="7" cy="7" r="2.2"/>
-              <line x1="7" y1="1" x2="7" y2="2"/>
-              <line x1="7" y1="12" x2="7" y2="13"/>
-              <line x1="1" y1="7" x2="2" y2="7"/>
-              <line x1="12" y1="7" x2="13" y2="7"/>
-              <line x1="2.8" y1="2.8" x2="3.5" y2="3.5"/>
-              <line x1="10.5" y1="10.5" x2="11.2" y2="11.2"/>
-              <line x1="11.2" y1="2.8" x2="10.5" y2="3.5"/>
-              <line x1="3.5" y1="10.5" x2="2.8" y2="11.2"/>
-            </svg>
-            Highlight
-          </span>
-          <span class="detail-value">{{ recipe.highlight|signed }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
-              <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z" fill="currentColor" opacity="0.55" stroke="none"/>
-              <path d="M9 2.5 A5 5 0 1 0 9 11.5 A4 4 0 1 1 9 2.5 Z"/>
-            </svg>
-            Shadow
-          </span>
-          <span class="detail-value">{{ recipe.shadow|signed }}</span>
-        </div>
-      </div>
-
-      {# Color (palette) / Sharpness (diamond) #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
-              <circle cx="7" cy="7" r="5.5"/>
-              <circle cx="5" cy="5.5" r="1.1" fill="currentColor" stroke="none"/>
-              <circle cx="9" cy="5" r="1.1" fill="currentColor" stroke="none"/>
-              <circle cx="10.2" cy="8.5" r="1.1" fill="currentColor" stroke="none"/>
-              <circle cx="4.2" cy="9.2" r="1.1" fill="currentColor" stroke="none"/>
-            </svg>
-            Color
-          </span>
-          <span class="detail-value">{{ recipe.color|signed }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
-              <polygon points="7,1 13,7 7,13 1,7"/>
-              <polygon points="7,3.5 10.5,7 7,10.5 3.5,7" fill="currentColor" opacity="0.25" stroke="none"/>
-            </svg>
-            Sharpness
-          </span>
-          <span class="detail-value">{{ recipe.sharpness|signed }}</span>
-        </div>
-      </div>
-
-      {# NR (funnel/filter) / Clarity (concentric circles) #}
-      <div class="detail-pair">
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5 Z" fill="currentColor" opacity="0.2"/>
-              <polyline points="1,2.5 13,2.5 8.5,7.5 8.5,12 5.5,10.5 5.5,7.5 Z"/>
-            </svg>
-            High ISO NR
-          </span>
-          <span class="detail-value">{{ recipe.high_iso_nr|signed }}</span>
-        </div>
-        <div class="detail-field">
-          <span class="detail-label">
-            <svg class="field-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.2">
-              <circle cx="7" cy="7" r="5.5"/>
-              <circle cx="7" cy="7" r="3.2"/>
-              <circle cx="7" cy="7" r="1" fill="currentColor" stroke="none"/>
-            </svg>
-            Clarity
-          </span>
-          <span class="detail-value">{{ recipe.clarity|signed }}</span>
-        </div>
-      </div>
-
-      <p class="detail-image-count">{{ recipe.image_count }} image{{ recipe.image_count|pluralize }}</p>
+      </div><!-- /.detail-fields -->
     </div>
 
     <!-- Actions -->
@@ -570,20 +737,24 @@
                   hx-target="#slot-overlay"
                   hx-swap="innerHTML">Send to camera</button>
         {% else %}
-          <div style="display:flex;align-items:center;gap:0.75rem;">
-            <button class="action-btn action-btn--disabled" disabled>Send to camera</button>
-            <span class="action-hint">Name the recipe first for sending it to camera.</span>
-          </div>
+          <button class="action-btn action-btn--disabled" disabled title="Name the recipe first for sending it to camera.">Send to camera</button>
         {% endif %}
         {% if recipe.image_count %}
-          <a class="action-btn action-btn--secondary" href="{% url 'gallery' %}?recipe_id={{ recipe.id }}">Browse images</a>
+          <a class="action-btn action-btn--secondary" href="{% url 'gallery' %}?recipe_id={{ recipe.id }}">Browse {{ recipe.image_count }} image{{ recipe.image_count|pluralize }}</a>
         {% endif %}
         <button class="action-btn action-btn--secondary"
                 hx-get="{% url 'recipe-card-modal' recipe_id=recipe.id %}"
                 hx-target="#card-overlay"
-                hx-swap="innerHTML">Create Recipe Card</button>
+                hx-swap="innerHTML">Create recipe card</button>
         <a class="action-btn action-btn--secondary" href="{% url 'edit-recipe' recipe_id=recipe.id %}">Edit recipe</a>
         <a class="action-btn action-btn--secondary" href="{% url 'create-recipe-version' recipe_id=recipe.id %}">Create new version</a>
+      </div>
+
+      <div class="detail-distribution">
+        <h2 class="detail-section-title">Distribution</h2>
+        <div class="detail-distribution-placeholder">
+          Image distribution over time — coming soon
+        </div>
       </div>
     </div>
 
@@ -606,6 +777,24 @@
 </style>
 
 <script>
+  (function () {
+    var wrap = document.querySelector('.wb-grid-readonly-wrap');
+    if (!wrap) return;
+    var selR = parseInt(wrap.dataset.r) || 0;
+    var selB = parseInt(wrap.dataset.b) || 0;
+    var neutral = 160, scale = 10;
+    for (var b = 9; b >= -9; b--) {
+      for (var r = -9; r <= 9; r++) {
+        var dot = document.createElement('div');
+        var red  = Math.round(Math.max(0, Math.min(255, neutral + r * scale)));
+        var blue = Math.round(Math.max(0, Math.min(255, neutral + b * scale)));
+        dot.style.backgroundColor = 'rgb(' + red + ',' + neutral + ',' + blue + ')';
+        dot.className = 'wb-dot' + (r === selR && b === selB ? ' wb-dot--selected' : '');
+        wrap.appendChild(dot);
+      }
+    }
+  })();
+
   function closeCardOverlay() {
     document.getElementById('card-overlay').hidden = true;
   }


### PR DESCRIPTION
- Switch from dark to light theme using brand color tokens
- Reorganise settings into labelled sections (Basic, Grain, White Balance, Dynamic Range, Color Chrome, BW Tone, Tone & Color, Detail) arranged in a two-column grid with label-left / value-right rows
- Add read-only WB colour grid with selected-cell highlight
- Redesign actions sidebar: full-width centred buttons, grey background, Distribution placeholder for future feature
- Replace 'Edit recipe name' button with pencil-icon Rename button