### PR TITLE
Add card layout option to place info/QR on either side

### DIFF
--- a/src/application/usecases/recipes/create_recipe_card.py
+++ b/src/application/usecases/recipes/create_recipe_card.py
@@ -12,6 +12,7 @@ def create_recipe_card(
     recipe_id: int,
     image_id: int | None,
     template: card_templates.CardTemplate,
+    info_side: card_templates.InfoSide = card_templates.DEFAULT_INFO_SIDE,
 ) -> models.RecipeCard:
     """
     Create a recipe card for the given recipe and persist it.
@@ -30,4 +31,5 @@ def create_recipe_card(
         template=template,
         background_image=background_image,
         output_dir=output_dir,
+        info_side=info_side,
     )

--- a/src/application/usecases/recipes/preview_recipe_card.py
+++ b/src/application/usecases/recipes/preview_recipe_card.py
@@ -12,6 +12,7 @@ def preview_recipe_card(
     recipe_id: int,
     image_id: int | None,
     template: card_templates.CardTemplate,
+    info_side: card_templates.InfoSide = card_templates.DEFAULT_INFO_SIDE,
 ) -> Path:
     """
     Generate a recipe card preview in /tmp/ and return its path.
@@ -27,10 +28,11 @@ def preview_recipe_card(
         models.Image.objects.get(pk=image_id) if image_id is not None else None
     )
     image_suffix = str(image_id) if image_id is not None else "none"
-    output_path = _TMP_DIR / f"recipe_preview_{recipe_id}_{template.template_name}_{image_suffix}.jpg"
+    output_path = _TMP_DIR / f"recipe_preview_{recipe_id}_{template.template_name}_{image_suffix}_{info_side}.jpg"
     return card_operations.preview_recipe_card_image(
         recipe=recipe,
         template=template,
         background_image=background_image,
         output_path=output_path,
+        info_side=info_side,
     )

--- a/src/domain/recipes/cards/operations.py
+++ b/src/domain/recipes/cards/operations.py
@@ -97,9 +97,13 @@ def _compose_card(
     recipe: models.FujifilmRecipe,
     template: card_templates.CardTemplate,
     background_image: models.Image | None,
+    info_side: card_templates.InfoSide,
 ) -> tuple[PILImage.Image, str, bool]:
     """
     Build the card PIL image. Returns (canvas, json_str, use_gradient).
+
+    *info_side* chooses which half holds the info text + logo; the QR code
+    goes on the opposite bottom corner.
     """
     target_w, target_h = template.output_size
     if background_image is None:
@@ -111,16 +115,17 @@ def _compose_card(
             canvas = canvas.filter(ImageFilter.GaussianBlur(radius=_BLUR_RADIUS))
 
     panel_w = target_w // 2
+    panel_x = 0 if info_side == "left" else target_w - panel_w
     overlay = PILImage.new("RGBA", (panel_w, target_h), (0, 0, 0, _PANEL_ALPHA))
     canvas_rgba = canvas.convert("RGBA")
-    canvas_rgba.paste(overlay, (0, 0), overlay)
+    canvas_rgba.paste(overlay, (panel_x, 0), overlay)
     canvas = canvas_rgba.convert("RGB")
 
     draw = ImageDraw.Draw(canvas)
     label_font = _load_font(_FONT_SIZE)
     value_font = _load_font(_FONT_SIZE)
     lines = card_queries.get_recipe_cover_lines(recipe=recipe, template=template)
-    x = _TEXT_PADDING
+    x = panel_x + _TEXT_PADDING
     y = _TEXT_PADDING
     if recipe.name:
         title_font = _load_font(_TITLE_FONT_SIZE)
@@ -137,7 +142,8 @@ def _compose_card(
     json_str = card_queries.get_recipe_as_json(recipe=recipe)
     qr_img = qrcode.make(json_str)
     qr_img = qr_img.resize((_QR_SIZE, _QR_SIZE), PILImage.Resampling.LANCZOS)
-    qr_pos = (target_w - _QR_SIZE - _QR_MARGIN, target_h - _QR_SIZE - _QR_MARGIN)
+    qr_x = _QR_MARGIN if info_side == "right" else target_w - _QR_SIZE - _QR_MARGIN
+    qr_pos = (qr_x, target_h - _QR_SIZE - _QR_MARGIN)
     canvas.paste(qr_img, qr_pos)
 
     if _LOGO_PATH.exists():
@@ -148,7 +154,7 @@ def _compose_card(
                 logo_rgba = logo_rgba.crop(bbox)
             content_h = int(_LOGO_WIDTH * logo_rgba.height / logo_rgba.width)
             logo = logo_rgba.resize((_LOGO_WIDTH, content_h), PILImage.Resampling.LANCZOS)
-        logo_x = _TEXT_PADDING
+        logo_x = panel_x + _TEXT_PADDING
         logo_y = target_h - content_h - _TEXT_PADDING
         white_bg = PILImage.new("RGBA", (_LOGO_WIDTH + _LOGO_PADDING * 2, content_h + _LOGO_PADDING * 2), (255, 255, 255, 255))
         canvas_rgba = canvas.convert("RGBA")
@@ -177,6 +183,7 @@ def preview_recipe_card_image(
     template: card_templates.CardTemplate,
     background_image: models.Image | None,
     output_path: Path,
+    info_side: card_templates.InfoSide = card_templates.DEFAULT_INFO_SIDE,
 ) -> Path:
     """
     Compose a recipe card image and save it to output_path. Return output_path.
@@ -186,7 +193,10 @@ def preview_recipe_card_image(
     overwrite the previous file rather than accumulating.
     """
     canvas, json_str, use_gradient = _compose_card(
-        recipe=recipe, template=template, background_image=background_image,
+        recipe=recipe,
+        template=template,
+        background_image=background_image,
+        info_side=info_side,
     )
     _save_card(canvas=canvas, filepath=output_path, json_str=json_str, use_gradient=use_gradient)
     return output_path
@@ -198,6 +208,7 @@ def create_recipe_card_image(
     template: card_templates.CardTemplate,
     background_image: models.Image | None,
     output_dir: Path,
+    info_side: card_templates.InfoSide = card_templates.DEFAULT_INFO_SIDE,
 ) -> Path:
     """
     Compose a recipe card image and save it to output_dir. Return the file path.
@@ -208,7 +219,10 @@ def create_recipe_card_image(
     the recipe JSON into the EXIF UserComment so the card can be re-imported.
     """
     canvas, json_str, use_gradient = _compose_card(
-        recipe=recipe, template=template, background_image=background_image,
+        recipe=recipe,
+        template=template,
+        background_image=background_image,
+        info_side=info_side,
     )
     filepath = output_dir / f"recipe_{recipe.pk}_{uuid.uuid4().hex[:8]}.jpg"
     _save_card(canvas=canvas, filepath=filepath, json_str=json_str, use_gradient=use_gradient)
@@ -221,6 +235,7 @@ def create_recipe_card(
     template: card_templates.CardTemplate,
     background_image: models.Image | None,
     output_dir: Path,
+    info_side: card_templates.InfoSide = card_templates.DEFAULT_INFO_SIDE,
 ) -> models.RecipeCard:
     """
     Create a recipe card image, persist a RecipeCard record, and publish an event.
@@ -233,6 +248,7 @@ def create_recipe_card(
         template=template,
         background_image=background_image,
         output_dir=output_dir,
+        info_side=info_side,
     )
     card = models.RecipeCard.create(
         filepath=str(filepath),

--- a/src/domain/recipes/cards/templates.py
+++ b/src/domain/recipes/cards/templates.py
@@ -3,6 +3,11 @@ from typing import Literal
 import attrs
 
 
+InfoSide = Literal["left", "right"]
+DEFAULT_INFO_SIDE: InfoSide = "left"
+INFO_SIDES: tuple[InfoSide, ...] = ("left", "right")
+
+
 @attrs.frozen
 class CardTemplate:
     label_style: Literal["long", "short"]

--- a/src/interfaces/templates/recipes/partials/recipe_card_modal.html
+++ b/src/interfaces/templates/recipes/partials/recipe_card_modal.html
@@ -3,7 +3,7 @@
     background: #fff;
     border-radius: 16px;
     padding: 2rem;
-    width: 960px;
+    width: 1340px;
     max-width: 95vw;
     max-height: 90vh;
     overflow-y: auto;
@@ -56,7 +56,7 @@
 
   .card-modal-body {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
     gap: 2rem;
     align-items: start;
   }
@@ -148,9 +148,33 @@
     margin-bottom: 1.5rem;
   }
 
+  .card-option-row {
+    display: flex;
+    align-items: stretch;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .card-option-group {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .card-option-group .card-section-label {
+    margin-bottom: 0.75rem;
+  }
+
+  .card-option-group .card-template-options {
+    flex: 1;
+    margin-bottom: 0;
+  }
+
   .card-template-option {
     position: relative;
     flex: 1;
+    display: flex;
   }
 
   .card-template-option input[type="radio"] {
@@ -161,7 +185,11 @@
   }
 
   .card-template-option label {
-    display: block;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 5.25rem;
     padding: 0.75rem 1rem;
     border-radius: 8px;
     border: 2px solid #e0e0e0;
@@ -246,40 +274,69 @@
         </div>
       {% endif %}
 
-      <p class="card-section-label">Label style</p>
-      <div class="card-template-options">
-        <div class="card-template-option">
-          <input type="radio" name="label_style" id="card-lbl-long" value="long" checked>
-          <label for="card-lbl-long">
-            <p class="card-template-name">Full labels</p>
-            <p class="card-template-desc">White Balance, Highlights…</p>
-          </label>
+      <div class="card-option-row">
+        <div class="card-option-group">
+          <p class="card-section-label">Label style</p>
+          <div class="card-template-options">
+            <div class="card-template-option">
+              <input type="radio" name="label_style" id="card-lbl-long" value="long" checked>
+              <label for="card-lbl-long">
+                <p class="card-template-name">Full labels</p>
+                <p class="card-template-desc">White Balance, Highlights…</p>
+              </label>
+            </div>
+            <div class="card-template-option">
+              <input type="radio" name="label_style" id="card-lbl-short" value="short">
+              <label for="card-lbl-short">
+                <p class="card-template-name">Short labels</p>
+                <p class="card-template-desc">WB, HL, SH…</p>
+              </label>
+            </div>
+          </div>
         </div>
-        <div class="card-template-option">
-          <input type="radio" name="label_style" id="card-lbl-short" value="short">
-          <label for="card-lbl-short">
-            <p class="card-template-name">Short labels</p>
-            <p class="card-template-desc">WB, HL, SH…</p>
-          </label>
+
+        <div class="card-option-group">
+          <p class="card-section-label">Background effect</p>
+          <div class="card-template-options">
+            <div class="card-template-option">
+              <input type="radio" name="bg_effect" id="card-bg-blur" value="blur" checked>
+              <label for="card-bg-blur">
+                <p class="card-template-name">Blur</p>
+                <p class="card-template-desc">Softens the background photo</p>
+              </label>
+            </div>
+            <div class="card-template-option">
+              <input type="radio" name="bg_effect" id="card-bg-sharp" value="sharp">
+              <label for="card-bg-sharp">
+                <p class="card-template-name">Sharp</p>
+                <p class="card-template-desc">Original photo, no blur</p>
+              </label>
+            </div>
+          </div>
         </div>
       </div>
 
-      <p class="card-section-label">Background effect</p>
-      <div class="card-template-options">
-        <div class="card-template-option">
-          <input type="radio" name="bg_effect" id="card-bg-blur" value="blur" checked>
-          <label for="card-bg-blur">
-            <p class="card-template-name">Blur</p>
-            <p class="card-template-desc">Softens the background photo</p>
-          </label>
+      <div class="card-option-row">
+        <div class="card-option-group">
+          <p class="card-section-label">Card layout</p>
+          <div class="card-template-options">
+            <div class="card-template-option">
+              <input type="radio" name="info_side" id="card-side-left" value="left" checked>
+              <label for="card-side-left">
+                <p class="card-template-name">Info left</p>
+                <p class="card-template-desc">QR code on the right</p>
+              </label>
+            </div>
+            <div class="card-template-option">
+              <input type="radio" name="info_side" id="card-side-right" value="right">
+              <label for="card-side-right">
+                <p class="card-template-name">Info right</p>
+                <p class="card-template-desc">QR code on the left</p>
+              </label>
+            </div>
+          </div>
         </div>
-        <div class="card-template-option">
-          <input type="radio" name="bg_effect" id="card-bg-sharp" value="sharp">
-          <label for="card-bg-sharp">
-            <p class="card-template-name">Sharp</p>
-            <p class="card-template-desc">Original photo, no blur</p>
-          </label>
-        </div>
+        <div class="card-option-group" aria-hidden="true"></div>
       </div>
 
       <button type="button"

--- a/src/interfaces/templates/recipes/partials/recipe_card_result.html
+++ b/src/interfaces/templates/recipes/partials/recipe_card_result.html
@@ -7,9 +7,13 @@
   }
 
   .card-result-image {
-    width: 100%;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 65vh;
     border-radius: 10px;
     display: block;
+    margin: 0 auto;
   }
 
   .card-result-created {
@@ -58,6 +62,6 @@
   {% endif %}
 {% elif preview_path %}
   <img class="card-result-image"
-       src="{% url 'recipe-card-preview-file' recipe_id=recipe_id %}?image_id={{ image_id|default:'' }}&label_style={{ label_style }}&bg_effect={{ bg_effect }}"
+       src="{% url 'recipe-card-preview-file' recipe_id=recipe_id %}?image_id={{ image_id|default:'' }}&label_style={{ label_style }}&bg_effect={{ bg_effect }}&info_side={{ info_side }}"
        alt="Recipe card preview">
 {% endif %}

--- a/src/interfaces/templates/recipes/partials/recipe_detail.html
+++ b/src/interfaces/templates/recipes/partials/recipe_detail.html
@@ -814,6 +814,12 @@
   document.addEventListener('keydown', function (e) {
     if (e.key !== 'Escape') return;
     var overlay = document.getElementById('card-overlay');
-    if (overlay && !overlay.hidden) closeCardOverlay();
+    if (overlay && !overlay.hidden) {
+      // Consume the event so the page-level Escape handler does not also
+      // close the underlying recipe detail overlay in the same keypress.
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      closeCardOverlay();
+    }
   });
 </script>

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -730,6 +730,10 @@ def _resolve_card_template(
     return card_templates.TEMPLATES.get(key, card_templates.LONG_LABEL)
 
 
+def _resolve_info_side(value: str) -> card_templates.InfoSide:
+    return "right" if value == "right" else "left"
+
+
 @_attrs.frozen
 class _RecipeCardModalContext:
     pk: int
@@ -783,11 +787,13 @@ class RecipeCardPreview(generic.View):
             label_style=request.GET.get("label_style", "long"),
             bg_effect=request.GET.get("bg_effect", "blur"),
         )
+        info_side = _resolve_info_side(request.GET.get("info_side", "left"))
         try:
             preview_path = preview_recipe_card_uc.preview_recipe_card(
                 recipe_id=recipe_id,
                 image_id=image_id,
                 template=template,
+                info_side=info_side,
             )
         except Exception:
             structlog.get_logger().exception("Unexpected error generating recipe card preview")
@@ -805,6 +811,7 @@ class RecipeCardPreview(generic.View):
                 "image_id": image_id,
                 "label_style": request.GET.get("label_style", "long"),
                 "bg_effect": request.GET.get("bg_effect", "blur"),
+                "info_side": info_side,
             },
         )
 
@@ -816,11 +823,13 @@ def recipe_card_preview_file_view(request: http.HttpRequest, recipe_id: int) -> 
         label_style=request.GET.get("label_style", "long"),
         bg_effect=request.GET.get("bg_effect", "blur"),
     )
+    info_side = _resolve_info_side(request.GET.get("info_side", "left"))
     try:
         preview_path = preview_recipe_card_uc.preview_recipe_card(
             recipe_id=recipe_id,
             image_id=image_id,
             template=template,
+            info_side=info_side,
         )
     except Exception:
         structlog.get_logger().exception("Unexpected error generating recipe card preview file")
@@ -844,11 +853,13 @@ class CreateRecipeCard(generic.View):
             label_style=request.POST.get("label_style", "long"),
             bg_effect=request.POST.get("bg_effect", "blur"),
         )
+        info_side = _resolve_info_side(request.POST.get("info_side", "left"))
         try:
             card = create_recipe_card_uc.create_recipe_card(
                 recipe_id=recipe_id,
                 image_id=image_id,
                 template=template,
+                info_side=info_side,
             )
         except Exception:
             structlog.get_logger().exception("Unexpected error creating recipe card")

--- a/tests/functional/test_create_recipe_card_view.py
+++ b/tests/functional/test_create_recipe_card_view.py
@@ -57,3 +57,46 @@ class TestCreateRecipeCard:
         response = client.post(f"/recipes/{recipe.pk}/card/partial/create/")
         soup = BeautifulSoup(response.content, "html.parser")
         assert soup.find(class_="card-result-download") is not None
+
+    def test_post_with_info_side_right_saves_card(self, client, tmp_path, settings):
+        settings.RECIPE_CARDS_DIR = str(tmp_path)
+        recipe = FujifilmRecipeFactory()
+        response = client.post(
+            f"/recipes/{recipe.pk}/card/partial/create/", {"info_side": "right"}
+        )
+        assert response.status_code == 200
+        assert models.RecipeCard.objects.filter(recipe=recipe).exists()
+
+    def test_post_with_invalid_info_side_is_treated_as_left(
+        self, client, tmp_path, settings
+    ):
+        settings.RECIPE_CARDS_DIR = str(tmp_path)
+        recipe = FujifilmRecipeFactory()
+        response = client.post(
+            f"/recipes/{recipe.pk}/card/partial/create/", {"info_side": "bogus"}
+        )
+        assert response.status_code == 200
+        assert models.RecipeCard.objects.filter(recipe=recipe).exists()
+
+
+@pytest.mark.django_db
+class TestRecipeCardPreview:
+    def test_get_with_info_side_right_returns_200(self, client, tmp_path, settings):
+        settings.RECIPE_CARDS_DIR = str(tmp_path)
+        recipe = FujifilmRecipeFactory()
+        response = client.get(
+            f"/recipes/{recipe.pk}/card/partial/preview/", {"info_side": "right"}
+        )
+        assert response.status_code == 200
+
+    def test_preview_image_src_carries_selected_info_side(
+        self, client, tmp_path, settings
+    ):
+        settings.RECIPE_CARDS_DIR = str(tmp_path)
+        recipe = FujifilmRecipeFactory()
+        response = client.get(
+            f"/recipes/{recipe.pk}/card/partial/preview/", {"info_side": "right"}
+        )
+        soup = BeautifulSoup(response.content, "html.parser")
+        img = soup.find("img", class_="card-result-image")
+        assert "info_side=right" in img["src"]

--- a/tests/integration/application/recipes/test_create_recipe_card.py
+++ b/tests/integration/application/recipes/test_create_recipe_card.py
@@ -23,6 +23,22 @@ class TestCreateRecipeCard:
         assert isinstance(card, models.RecipeCard)
         assert card.pk is not None
 
+    def test_returns_recipe_card_record_with_info_side_right(
+        self, tmp_path: Path, settings: object
+    ) -> None:
+        settings.RECIPE_CARDS_DIR = str(tmp_path)  # type: ignore[attr-defined]
+        recipe = FujifilmRecipeFactory()
+
+        card = uc.create_recipe_card(
+            recipe_id=recipe.pk,
+            image_id=None,
+            template=card_templates.LONG_LABEL,
+            info_side="right",
+        )
+
+        assert isinstance(card, models.RecipeCard)
+        assert Path(card.filepath).exists()
+
     def test_raises_if_recipe_does_not_exist(self, tmp_path: Path, settings: object) -> None:
         settings.RECIPE_CARDS_DIR = str(tmp_path)  # type: ignore[attr-defined]
 

--- a/tests/integration/application/recipes/test_preview_recipe_card.py
+++ b/tests/integration/application/recipes/test_preview_recipe_card.py
@@ -56,6 +56,26 @@ class TestPreviewRecipeCard:
 
         assert path1 == path2
 
+    def test_different_info_side_produces_different_paths(self) -> None:
+        recipe = FujifilmRecipeFactory()
+
+        path_left = uc.preview_recipe_card(
+            recipe_id=recipe.pk,
+            image_id=None,
+            template=card_templates.LONG_LABEL,
+            info_side="left",
+        )
+        path_right = uc.preview_recipe_card(
+            recipe_id=recipe.pk,
+            image_id=None,
+            template=card_templates.LONG_LABEL,
+            info_side="right",
+        )
+
+        assert path_left != path_right
+        assert path_left.exists()
+        assert path_right.exists()
+
     def test_different_templates_produce_different_paths(self) -> None:
         recipe = FujifilmRecipeFactory()
 

--- a/tests/integration/domain/test_create_recipe_card.py
+++ b/tests/integration/domain/test_create_recipe_card.py
@@ -225,3 +225,41 @@ class TestRecipeCardLogo:
             r, g, b = img.getpixel((x, y))
         # The gradient background at this position is near-black (~30, 20, 70).
         assert r > 200 and g > 200 and b > 200
+
+
+@pytest.mark.django_db
+class TestRecipeCardInfoSide:
+    def _max_title_brightness(self, img: PILImage.Image, panel_x: int) -> int:
+        # The title sits in the top padding strip of the info panel. This region
+        # is well above the QR code, so it isolates the info-panel placement.
+        p = card_operations._TEXT_PADDING
+        region = img.crop(
+            (panel_x + p, p, panel_x + p + 300, p + card_operations._TITLE_LINE_HEIGHT)
+        )
+        return region.getextrema()[0][1]  # max R value
+
+    def test_left_keeps_info_panel_in_left_half(self, tmp_path: Path) -> None:
+        recipe = FujifilmRecipeFactory(name="My Recipe")
+        filepath = card_operations.create_recipe_card_image(
+            recipe=recipe,
+            template=card_templates.LONG_LABEL,
+            background_image=None,
+            output_dir=tmp_path,
+            info_side="left",
+        )
+        with PILImage.open(filepath) as img:
+            assert self._max_title_brightness(img, panel_x=0) > 200
+            assert self._max_title_brightness(img, panel_x=img.width // 2) < 100
+
+    def test_right_moves_info_panel_to_right_half(self, tmp_path: Path) -> None:
+        recipe = FujifilmRecipeFactory(name="My Recipe")
+        filepath = card_operations.create_recipe_card_image(
+            recipe=recipe,
+            template=card_templates.LONG_LABEL,
+            background_image=None,
+            output_dir=tmp_path,
+            info_side="right",
+        )
+        with PILImage.open(filepath) as img:
+            assert self._max_title_brightness(img, panel_x=img.width // 2) > 200
+            assert self._max_title_brightness(img, panel_x=0) < 100

--- a/tests/unit/domain/test_create_recipe_card.py
+++ b/tests/unit/domain/test_create_recipe_card.py
@@ -167,3 +167,74 @@ class TestComposeCardLogoFallback:
         assert output_path.exists()
 
 
+class TestComposeCardInfoSide:
+    def _generate_card(
+        self, tmp_path: Path, info_side: card_templates.InfoSide
+    ) -> Path:
+        recipe = MagicMock()
+        recipe.name = "My Recipe"
+        recipe.pk = 1
+        output_path = tmp_path / f"card_{info_side}.jpg"
+        with (
+            patch.object(card_operations, "_LOGO_PATH", tmp_path / "no_logo.png"),
+            patch.object(card_operations.card_queries, "get_recipe_cover_lines", return_value=()),
+            patch.object(card_operations.card_queries, "get_recipe_as_json", return_value='{"v":1}'),
+        ):
+            card_operations.preview_recipe_card_image(
+                recipe=recipe,
+                template=card_templates.LONG_LABEL,
+                background_image=None,
+                output_path=output_path,
+                info_side=info_side,
+            )
+        return output_path
+
+    def _max_brightness(self, filepath: Path, x0: int) -> int:
+        p = card_operations._TEXT_PADDING
+        with PILImage.open(filepath) as img:
+            region = img.crop((x0, p, x0 + 300, p + card_operations._TITLE_LINE_HEIGHT))
+        return region.getextrema()[0][1]  # max R value in the region
+
+    def test_left_side_renders_title_in_left_half(self, tmp_path: Path) -> None:
+        filepath = self._generate_card(tmp_path, "left")
+
+        left_x = card_operations._TEXT_PADDING
+        right_x = 1080 // 2 + card_operations._TEXT_PADDING
+        assert self._max_brightness(filepath, left_x) > 200
+        assert self._max_brightness(filepath, right_x) < 100
+
+    def test_right_side_renders_title_in_right_half(self, tmp_path: Path) -> None:
+        filepath = self._generate_card(tmp_path, "right")
+
+        left_x = card_operations._TEXT_PADDING
+        right_x = 1080 // 2 + card_operations._TEXT_PADDING
+        assert self._max_brightness(filepath, right_x) > 200
+        assert self._max_brightness(filepath, left_x) < 100
+
+    def test_default_info_side_matches_explicit_left(self, tmp_path: Path) -> None:
+        recipe = MagicMock()
+        recipe.name = "My Recipe"
+        recipe.pk = 1
+        paths = {}
+        for label, kwargs in (
+            ("default", {}),
+            ("left", {"info_side": "left"}),
+        ):
+            output_path = tmp_path / f"card_{label}.jpg"
+            with (
+                patch.object(card_operations, "_LOGO_PATH", tmp_path / "no_logo.png"),
+                patch.object(card_operations.card_queries, "get_recipe_cover_lines", return_value=()),
+                patch.object(card_operations.card_queries, "get_recipe_as_json", return_value='{"v":1}'),
+            ):
+                card_operations.preview_recipe_card_image(
+                    recipe=recipe,
+                    template=card_templates.LONG_LABEL,
+                    background_image=None,
+                    output_path=output_path,
+                    **kwargs,
+                )
+            paths[label] = output_path.read_bytes()
+
+        assert paths["default"] == paths["left"]
+
+


### PR DESCRIPTION
Recipe cards previously hard-coded the info text and logo to the left half and the QR code to the bottom-right. Users can now choose the orientation when creating or previewing a card.

- Introduce an `InfoSide` literal ("left"/"right") with a default of "left", threaded as an orthogonal keyword argument through the view, both usecases (create and preview), and the drawing operation; existing call sites keep the previous output

- The compose step derives the panel, text, logo, and QR x-positions from the chosen side, so "right" mirrors the layout (info/logo right, QR bottom-left)

- Add a "Card layout" radio group to the create-recipe-card modal and carry the selection through the live preview; the preview filename includes the side so left/right previews no longer collide

- QR re-import is unaffected: the decoder scans the whole image and does not assume a fixed QR position