### PR TITLE
Add make import target and improve virtualenv docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ update:
 	@echo ""
 	@echo "Done. Run 'make run' to start the server."
 
+## import PATH=…  — import images from a directory (e.g. make import PATH=~/Pictures/Fujifilm)
+import:
+	@$(PYTHON) manage.py process_images $(PATH)
+
 ## run         — start the Django development server
 run:
 	@git fetch origin main --quiet 2>/dev/null; \

--- a/README.md
+++ b/README.md
@@ -54,13 +54,10 @@ cd filmcase
 **Set up the project:**
 
 ```bash
-make setup-lite   # creates venv, installs deps, generates SQLite config, runs migrations
-make run          # start the development server
-make update       # pull latest changes, install new deps, run migrations
+make setup-lite              # creates venv, installs deps, generates SQLite config, runs migrations
+make import PATH=/path/to/images   # import your image collection
+make run                     # start the development server
 ```
-
-Images are processed sequentially when you run `python manage.py process_images`. No
-background worker is needed.
 
 ---
 
@@ -203,7 +200,7 @@ Python 3.11+ is required.
 Before using the web interface, you need to process your images so their EXIF data and recipe information are stored in the database.
 
 ```bash
-python manage.py process_images /path/to/your/images
+make import PATH=/path/to/your/images
 ```
 
 The command behaves according to your install mode:
@@ -237,7 +234,7 @@ Visit `/images/` to see all processed images. Use the filter controls to narrow 
 
 ### Process new images
 
-Re-run `process_images` pointing at any directory containing new images. Already-processed images are updated in place with fresh EXIF data. Images without Fujifilm EXIF data are skipped.
+Re-run `make import PATH=…` pointing at any directory containing new images. Already-processed images are updated in place with fresh EXIF data. Images without Fujifilm EXIF data are skipped.
 
 ### Rate images
 

--- a/docs/management_commands.md
+++ b/docs/management_commands.md
@@ -3,21 +3,39 @@
 Management commands are run from the terminal and handle tasks that don't belong in the
 web interface (yet)— bulk imports, maintenance, and camera inspection.
 
+## Running commands
+
+The project uses a virtualenv located at `.venv/`. To run any management command, prefix
+it with `.venv/bin/python` instead of `python`:
+
+```bash
+.venv/bin/python manage.py <command> [args]
+```
+
+Alternatively, activate the virtualenv for your shell session first:
+
+```bash
+source .venv/bin/activate
+python manage.py <command> [args]
+```
+
 ---
 
 ## Importing images
 
 ```
 python manage.py process_images <folder>
-python manage.py process_images_sync <folder>
 ```
 
-Both commands scan a folder for JPEG images taken with a Fujifilm camera and import them
-into the application, extracting recipe and EXIF data from each file.
+Scans a folder for JPEG images taken with a Fujifilm camera and imports them into the
+application, extracting recipe and EXIF data from each file.
 
-`process_images` queues the work in the background (requires Celery to be running).
-`process_images_sync` processes everything immediately in the terminal, which is simpler for
-one-off imports when Celery is not set up.
+Behaviour depends on your install mode:
+
+- **Lite install** (`USE_ASYNC_TASKS=False`): images are processed one at a time in the
+  foreground. The terminal blocks until all images are done.
+- **Full install** (`USE_ASYNC_TASKS=True`): one Celery task is enqueued per image and
+  processed in parallel by the worker (start it first with `make worker`).
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/gosku/Filmcase/issues/51

## What

A user reported that running `python manage.py process_images` was confusing because the virtualenv isn't activated by default, making it non-obvious that `.venv/bin/python` is needed. This PR makes importing images a first-class `make` target and improves the docs for users unfamiliar with virtualenvs.

## Changes

- **`Makefile`** — add `make import PATH=…` target, which wraps `manage.py process_images` using the project's own `.venv/bin/python`. It also appears in `make help`.

- **`README.md`** — reorder the lite install quick-start to the logical sequence: setup → import → run. Replace all references to bare `python manage.py process_images` with `make import PATH=…`.

- **`docs/management_commands.md`** — add a "Running commands" section at the top explaining how to use `.venv/bin/python` or activate the virtualenv before running any management command. Remove the defunct `process_images_sync` entry.
