### PR TITLE
Add sensors to filters and add other missing filters

### DIFF
--- a/src/domain/images/filter_queries.py
+++ b/src/domain/images/filter_queries.py
@@ -8,6 +8,9 @@ from src.data import models
 
 _NOTABLE_RECIPE_MIN_IMAGES = 50
 
+SENSOR_NONE_VALUE = "none"
+SENSOR_NONE_LABEL = "Not assigned"
+
 
 def decimal_filter_str(value: object) -> str:
     """Convert a DB Decimal value to a filter string, dropping redundant .0 suffixes."""
@@ -16,6 +19,41 @@ def decimal_filter_str(value: object) -> str:
         return str(int(n)) if n == int(n) else str(value)
     except (TypeError, ValueError):
         return str(value)
+
+
+def filter_images_by_sensors(
+    qs: db_models.QuerySet[models.Image],
+    sensor_values: Sequence[str],
+) -> db_models.QuerySet[models.Image]:
+    named = [v for v in sensor_values if v != SENSOR_NONE_VALUE]
+    include_none = SENSOR_NONE_VALUE in sensor_values
+    if named and include_none:
+        return qs.filter(
+            db_models.Q(fujifilm_recipe__sensors__name__in=named)
+            | db_models.Q(fujifilm_recipe__sensors__isnull=True)
+        ).distinct()
+    if named:
+        return qs.filter(fujifilm_recipe__sensors__name__in=named).distinct()
+    if include_none:
+        return qs.filter(fujifilm_recipe__sensors__isnull=True)
+    return qs
+
+
+def filter_recipes_by_sensors(
+    qs: db_models.QuerySet[models.FujifilmRecipe],
+    sensor_values: Sequence[str],
+) -> db_models.QuerySet[models.FujifilmRecipe]:
+    named = [v for v in sensor_values if v != SENSOR_NONE_VALUE]
+    include_none = SENSOR_NONE_VALUE in sensor_values
+    if named and include_none:
+        return qs.filter(
+            db_models.Q(sensors__name__in=named) | db_models.Q(sensors__isnull=True)
+        ).distinct()
+    if named:
+        return qs.filter(sensors__name__in=named).distinct()
+    if include_none:
+        return qs.filter(sensors__isnull=True)
+    return qs
 
 
 RECIPE_FILTER_FIELDS = [
@@ -62,6 +100,49 @@ def get_sidebar_filter_options(
             options  – list of dicts: value, count, available, selected
             selected – list of currently selected string values for this field
     """
+    sensor_selected: Sequence[str] = active_filters.get("sensors", [])
+    sensor_base_qs = models.Image.objects.filter(fujifilm_recipe__isnull=False)
+    recipe_ids = active_filters.get("recipe_id", [])
+    if recipe_ids:
+        sensor_base_qs = sensor_base_qs.filter(fujifilm_recipe_id__in=recipe_ids)
+    for other_field, values in active_filters.items():
+        if other_field in ("recipe_id", "sensors") or not values:
+            continue
+        sensor_base_qs = sensor_base_qs.filter(**{f"fujifilm_recipe__{other_field}__in": values})
+
+    sensor_counts: dict[str, int] = {
+        row["fujifilm_recipe__sensors__name"]: row["count"]
+        for row in (
+            sensor_base_qs
+            .filter(fujifilm_recipe__sensors__isnull=False)
+            .values("fujifilm_recipe__sensors__name")
+            .annotate(count=db_models.Count("id", distinct=True))
+        )
+    }
+    no_sensor_count = sensor_base_qs.filter(fujifilm_recipe__sensors__isnull=True).count()
+    if no_sensor_count:
+        sensor_counts[SENSOR_NONE_VALUE] = no_sensor_count
+
+    all_sensor_values: set[str] = set(sensor_counts) | set(sensor_selected)
+    sorted_sensor_values = sorted(
+        all_sensor_values,
+        key=lambda v: (0 if v in sensor_counts else 1, 1 if v == SENSOR_NONE_VALUE else 0, v),
+    )
+    _sensor_section: dict[str, object] = {
+        "label": "Sensor",
+        "options": [
+            {
+                "value": v,
+                "label": SENSOR_NONE_LABEL if v == SENSOR_NONE_VALUE else v,
+                "count": sensor_counts.get(v, 0),
+                "available": v in sensor_counts,
+                "selected": v in sensor_selected,
+            }
+            for v in sorted_sensor_values
+        ],
+        "selected": sensor_selected,
+    }
+
     result: dict[str, dict[str, object]] = {}
 
     for field, label in RECIPE_FILTER_FIELDS:
@@ -72,16 +153,19 @@ def get_sidebar_filter_options(
         # OTHER active filters (faceted search — own field excluded).
         # recipe_id is a cross-cutting filter: it always applies regardless of
         # which field is being computed, since it narrows to specific recipes.
-        base_qs = models.Image.objects.filter(fujifilm_recipe__isnull=False)
+        base_qs: db_models.QuerySet[models.Image] = models.Image.objects.filter(fujifilm_recipe__isnull=False)
         recipe_ids = active_filters.get("recipe_id", [])
         if recipe_ids:
             base_qs = base_qs.filter(fujifilm_recipe_id__in=recipe_ids)
         for other_field, values in active_filters.items():
             if other_field in ("recipe_id", field) or not values:
                 continue
-            base_qs = base_qs.filter(
-                **{f"fujifilm_recipe__{other_field}__in": values}
-            )
+            if other_field == "sensors":
+                base_qs = filter_images_by_sensors(base_qs, values)
+            else:
+                base_qs = base_qs.filter(
+                    **{f"fujifilm_recipe__{other_field}__in": values}
+                )
 
         # Exclude null / empty values from the option set.
         if is_numeric:
@@ -133,6 +217,8 @@ def get_sidebar_filter_options(
             ],
             "selected": selected_values,
         }
+        if field == "film_simulation":
+            result["sensors"] = _sensor_section
 
     return result
 
@@ -142,7 +228,7 @@ def get_filtered_images(
     active_filters: Mapping[str, Sequence[str]],
     rating_first: bool,
 ) -> db_models.QuerySet[models.Image]:
-    qs = models.Image.objects.select_related("fujifilm_recipe")
+    qs: db_models.QuerySet[models.Image] = models.Image.objects.select_related("fujifilm_recipe")
     recipe_ids = active_filters.get("recipe_id", [])
     if recipe_ids:
         qs = qs.filter(fujifilm_recipe_id__in=recipe_ids)
@@ -150,6 +236,9 @@ def get_filtered_images(
         values = active_filters.get(field, [])
         if values:
             qs = qs.filter(**{f"fujifilm_recipe__{field}__in": values})
+    sensor_values = active_filters.get("sensors", [])
+    if sensor_values:
+        qs = filter_images_by_sensors(qs, sensor_values)
     if rating_first:
         return qs.order_by("-rating", "-taken_at", "id")
     return qs.order_by("-taken_at", "id")
@@ -162,9 +251,13 @@ def _recipe_options(
 ) -> dict[str, object]:
     selected = active_filters.get("recipe_id", [])
 
-    filtered_qs = models.Image.objects.filter(fujifilm_recipe__isnull=False)
+    filtered_qs: db_models.QuerySet[models.Image] = models.Image.objects.filter(fujifilm_recipe__isnull=False)
     for field, values in active_field_filters.items():
-        if values:
+        if not values:
+            continue
+        if field == "sensors":
+            filtered_qs = filter_images_by_sensors(filtered_qs, values)
+        else:
             filtered_qs = filtered_qs.filter(**{f"fujifilm_recipe__{field}__in": values})
     filtered_counts = {
         str(row["fujifilm_recipe_id"]): row["count"]

--- a/src/domain/images/filter_queries.py
+++ b/src/domain/images/filter_queries.py
@@ -8,6 +8,16 @@ from src.data import models
 
 _NOTABLE_RECIPE_MIN_IMAGES = 50
 
+
+def decimal_filter_str(value: object) -> str:
+    """Convert a DB Decimal value to a filter string, dropping redundant .0 suffixes."""
+    try:
+        n = float(value)  # type: ignore[arg-type]
+        return str(int(n)) if n == int(n) else str(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
 RECIPE_FILTER_FIELDS = [
     ("film_simulation", "Film Simulation"),
     ("dynamic_range", "Dynamic Range"),
@@ -19,6 +29,12 @@ RECIPE_FILTER_FIELDS = [
     ("white_balance", "White Balance"),
     ("white_balance_red", "WB Red"),
     ("white_balance_blue", "WB Blue"),
+    ("highlight", "Highlight"),
+    ("shadow", "Shadow"),
+    ("color", "Color"),
+    ("sharpness", "Sharpness"),
+    ("high_iso_nr", "High ISO NR"),
+    ("clarity", "Clarity"),
 ]
 
 
@@ -50,7 +66,7 @@ def get_sidebar_filter_options(
 
     for field, label in RECIPE_FILTER_FIELDS:
         model_field = models.FujifilmRecipe._meta.get_field(field)
-        is_integer = isinstance(model_field, db_models.IntegerField)
+        is_numeric = isinstance(model_field, (db_models.IntegerField, db_models.DecimalField))
 
         # Base queryset: only images that have a recipe, filtered by all
         # OTHER active filters (faceted search — own field excluded).
@@ -68,7 +84,7 @@ def get_sidebar_filter_options(
             )
 
         # Exclude null / empty values from the option set.
-        if is_integer:
+        if is_numeric:
             base_qs = base_qs.exclude(**{f"fujifilm_recipe__{field}__isnull": True})
         else:
             base_qs = base_qs.exclude(**{f"fujifilm_recipe__{field}": ""})
@@ -76,7 +92,7 @@ def get_sidebar_filter_options(
         # Aggregate counts; normalise DB values to strings so they match
         # URL param strings throughout the rest of the logic.
         available_counts: dict[str, int] = {
-            str(row[f"fujifilm_recipe__{field}"]): row["count"]
+            decimal_filter_str(row[f"fujifilm_recipe__{field}"]): row["count"]
             for row in (
                 base_qs
                 .values(f"fujifilm_recipe__{field}")
@@ -90,11 +106,11 @@ def get_sidebar_filter_options(
         all_values: set[str] = set(available_counts.keys()) | set(selected_values)
 
         # Sort: available values first, then unavailable; within each group
-        # sort numerically for integer fields, alphabetically for text fields.
-        if is_integer:
-            def _sort_key(v: str) -> tuple[int, int]:
+        # sort numerically for numeric fields, alphabetically for text fields.
+        if is_numeric:
+            def _sort_key(v: str) -> tuple[int, float]:
                 try:
-                    return (0 if v in available_counts else 1, int(v))
+                    return (0 if v in available_counts else 1, float(v))
                 except (ValueError, TypeError):
                     return (0 if v in available_counts else 1, 0)
             sorted_values = sorted(all_values, key=_sort_key)

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -556,6 +556,48 @@ def get_recipe_sidebar_filter_options(
 
     *name_search* is applied to all facet counts so they reflect the current search.
     """
+    sensor_selected: Sequence[str] = active_filters.get("sensors", [])
+    sensor_base_qs = models.FujifilmRecipe.objects.all()
+    if name_search:
+        sensor_base_qs = sensor_base_qs.filter(Q(name__icontains=name_search))
+    for other_field, values in active_filters.items():
+        if other_field == "sensors" or not values:
+            continue
+        sensor_base_qs = sensor_base_qs.filter(**{f"{other_field}__in": values})
+
+    sensor_counts: dict[str, int] = {
+        row["sensors__name"]: row["count"]
+        for row in (
+            sensor_base_qs
+            .filter(sensors__isnull=False)
+            .values("sensors__name")
+            .annotate(count=Count("pk", distinct=True))
+        )
+    }
+    no_sensor_count = sensor_base_qs.filter(sensors__isnull=True).count()
+    if no_sensor_count:
+        sensor_counts[filter_queries.SENSOR_NONE_VALUE] = no_sensor_count
+
+    all_sensor_values: set[str] = set(sensor_counts) | set(sensor_selected)
+    sorted_sensor_values = sorted(
+        all_sensor_values,
+        key=lambda v: (0 if v in sensor_counts else 1, 1 if v == filter_queries.SENSOR_NONE_VALUE else 0, v),
+    )
+    _sensor_section: dict[str, object] = {
+        "label": "Sensor",
+        "options": [
+            {
+                "value": v,
+                "label": filter_queries.SENSOR_NONE_LABEL if v == filter_queries.SENSOR_NONE_VALUE else v,
+                "count": sensor_counts.get(v, 0),
+                "available": v in sensor_counts,
+                "selected": v in sensor_selected,
+            }
+            for v in sorted_sensor_values
+        ],
+        "selected": sensor_selected,
+    }
+
     result: dict[str, dict[str, object]] = {}
     for field, label in filter_queries.RECIPE_FILTER_FIELDS:
         model_field = models.FujifilmRecipe._meta.get_field(field)
@@ -567,7 +609,10 @@ def get_recipe_sidebar_filter_options(
         for other_field, values in active_filters.items():
             if other_field == field or not values:
                 continue
-            base_qs = base_qs.filter(**{f"{other_field}__in": values})
+            if other_field == "sensors":
+                base_qs = filter_queries.filter_recipes_by_sensors(base_qs, values)
+            else:
+                base_qs = base_qs.filter(**{f"{other_field}__in": values})
         if is_numeric:
             base_qs = base_qs.exclude(**{f"{field}__isnull": True})
         else:
@@ -606,6 +651,9 @@ def get_recipe_sidebar_filter_options(
             ],
             "selected": selected_values,
         }
+        if field == "film_simulation":
+            result["sensors"] = _sensor_section
+
     return result
 
 
@@ -660,9 +708,16 @@ def get_recipe_gallery_data(
         ),
         fallback_cover_image_id=Subquery(cover_subquery),
     )
+    sensor_values = active_filters.get("sensors", [])
     for field, values in active_filters.items():
-        if values:
-            qs = qs.filter(**{f"{field}__in": values})
+        if not values or field == "sensors":
+            continue
+        qs = qs.filter(**{f"{field}__in": values})
+    if sensor_values:
+        matching_pks = filter_queries.filter_recipes_by_sensors(
+            models.FujifilmRecipe.objects.all(), sensor_values
+        ).values("pk")
+        qs = qs.filter(pk__in=matching_pks)
     if name_search:
         qs = qs.filter(Q(name__icontains=name_search))
     qs = qs.order_by("-has_name", "-image_count", "pk")

--- a/src/domain/recipes/queries.py
+++ b/src/domain/recipes/queries.py
@@ -559,7 +559,7 @@ def get_recipe_sidebar_filter_options(
     result: dict[str, dict[str, object]] = {}
     for field, label in filter_queries.RECIPE_FILTER_FIELDS:
         model_field = models.FujifilmRecipe._meta.get_field(field)
-        is_integer = isinstance(model_field, db_models.IntegerField)
+        is_numeric = isinstance(model_field, (db_models.IntegerField, db_models.DecimalField))
 
         base_qs = models.FujifilmRecipe.objects.all()
         if name_search:
@@ -568,22 +568,22 @@ def get_recipe_sidebar_filter_options(
             if other_field == field or not values:
                 continue
             base_qs = base_qs.filter(**{f"{other_field}__in": values})
-        if is_integer:
+        if is_numeric:
             base_qs = base_qs.exclude(**{f"{field}__isnull": True})
         else:
             base_qs = base_qs.exclude(**{field: ""})
 
         available_counts: dict[str, int] = {
-            str(row[field]): row["count"]
+            filter_queries.decimal_filter_str(row[field]): row["count"]
             for row in base_qs.values(field).annotate(count=Count("pk"))
         }
         selected_values = active_filters.get(field, [])
         all_values: set[str] = set(available_counts) | set(selected_values)
 
-        if is_integer:
-            def _sort_key(v: str) -> tuple[int, int]:
+        if is_numeric:
+            def _sort_key(v: str) -> tuple[int, float]:
                 try:
-                    return (0 if v in available_counts else 1, int(v))
+                    return (0 if v in available_counts else 1, float(v))
                 except (ValueError, TypeError):
                     return (0 if v in available_counts else 1, 0)
             sorted_values = sorted(all_values, key=_sort_key)

--- a/src/interfaces/templates/images/_sidebar_filters.html
+++ b/src/interfaces/templates/images/_sidebar_filters.html
@@ -10,7 +10,7 @@
                      name="{{ field }}"
                      value="{{ option.value }}"
                      {% if option.selected %}checked{% endif %}>
-              <span class="filter-option-value">{{ option.value }}</span>
+              <span class="filter-option-value">{{ option.label|default:option.value }}</span>
               <span class="filter-option-count">({{ option.count }})</span>
             </label>
           {% endfor %}

--- a/src/interfaces/templates/recipes/includes/sidebar_filters.html
+++ b/src/interfaces/templates/recipes/includes/sidebar_filters.html
@@ -10,7 +10,7 @@
                      name="{{ field }}"
                      value="{{ option.value }}"
                      {% if option.selected %}checked{% endif %}>
-              <span class="filter-option-value">{{ option.value }}</span>
+              <span class="filter-option-value">{{ option.label|default:option.value }}</span>
               <span class="filter-option-count">({{ option.count }})</span>
             </label>
           {% endfor %}

--- a/src/interfaces/views.py
+++ b/src/interfaces/views.py
@@ -54,6 +54,9 @@ def _active_filters_from_request(request: http.HttpRequest) -> dict[str, list[st
     recipe_ids = request.GET.getlist("recipe_id")
     if recipe_ids:
         filters["recipe_id"] = recipe_ids
+    sensor_values = request.GET.getlist("sensors")
+    if sensor_values:
+        filters["sensors"] = sensor_values
     return filters
 
 
@@ -294,11 +297,15 @@ class SetRecipeCoverImage(generic.View):
 
 
 def _recipe_explorer_filters_from_request(request: http.HttpRequest) -> dict[str, list[str]]:
-    return {
+    filters = {
         field: request.GET.getlist(field)
         for field, _ in filter_queries.RECIPE_FILTER_FIELDS
         if request.GET.getlist(field)
     }
+    sensor_values = request.GET.getlist("sensors")
+    if sensor_values:
+        filters["sensors"] = sensor_values
+    return filters
 
 
 def recipes_explorer_view(request: http.HttpRequest) -> http.HttpResponse:

--- a/tests/integration/domain/test_filter_queries.py
+++ b/tests/integration/domain/test_filter_queries.py
@@ -14,6 +14,7 @@ class TestGetSidebarFilterOptionsNoFilters:
             "grain_roughness", "grain_size", "color_chrome_effect",
             "color_chrome_fx_blue", "white_balance",
             "white_balance_red", "white_balance_blue",
+            "highlight", "shadow", "color", "sharpness", "high_iso_nr", "clarity",
         ]
         assert list(result.keys()) == expected_fields
 
@@ -154,6 +155,29 @@ class TestGetSidebarFilterOptionsUnavailableValues:
         unavailable_indices = [i for i, o in enumerate(options) if not o["available"]]
         if available_indices and unavailable_indices:
             assert max(available_indices) < min(unavailable_indices)
+
+
+@pytest.mark.django_db
+class TestGetSidebarFilterOptionsDecimalFields:
+    def test_null_decimal_recipes_excluded_from_options(self):
+        # Factory leaves decimal fields as None; they must not appear in options.
+        recipe = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=recipe)
+
+        result = get_sidebar_filter_options({})
+
+        assert result["highlight"]["options"] == []
+
+    def test_decimal_field_values_sort_numerically(self):
+        recipe_a = FujifilmRecipeFactory(highlight="-2.0", white_balance_red=0)
+        recipe_b = FujifilmRecipeFactory(highlight="1.5", white_balance_red=1)
+        ImageFactory(fujifilm_recipe=recipe_a)
+        ImageFactory(fujifilm_recipe=recipe_b)
+
+        result = get_sidebar_filter_options({})
+
+        values = [o["value"] for o in result["highlight"]["options"]]
+        assert values.index("-2") < values.index("1.5")
 
 
 @pytest.mark.django_db

--- a/tests/integration/domain/test_filter_queries.py
+++ b/tests/integration/domain/test_filter_queries.py
@@ -1,6 +1,7 @@
 import pytest
 
-from src.domain.images.filter_queries import get_sidebar_filter_options
+from src.domain.images.filter_queries import SENSOR_NONE_VALUE, get_sidebar_filter_options
+from src.domain.recipes.operations import set_recipe_sensors
 from tests.factories import FujifilmRecipeFactory, ImageFactory
 
 
@@ -10,7 +11,8 @@ class TestGetSidebarFilterOptionsNoFilters:
         result = get_sidebar_filter_options({})
 
         expected_fields = [
-            "film_simulation", "dynamic_range", "d_range_priority",
+            "film_simulation", "sensors",
+            "dynamic_range", "d_range_priority",
             "grain_roughness", "grain_size", "color_chrome_effect",
             "color_chrome_fx_blue", "white_balance",
             "white_balance_red", "white_balance_blue",
@@ -201,3 +203,67 @@ class TestGetSidebarFilterOptionsIntegerFields:
         wb_opts = {o["value"]: o for o in result["white_balance_red"]["options"]}
         assert wb_opts["3"]["selected"] is True
         assert wb_opts["3"]["available"] is True
+
+
+@pytest.mark.django_db
+class TestGetSidebarFilterOptionsSensorField:
+    def test_sensor_section_is_empty_when_no_sensors_assigned(self):
+        recipe = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=recipe)
+
+        result = get_sidebar_filter_options({})
+
+        # The sensor section always exists but has no named-sensor options;
+        # only the "Not assigned" sentinel appears (for the image whose recipe
+        # has no sensor).
+        sensor_values = {o["value"] for o in result["sensors"]["options"]}
+        assert SENSOR_NONE_VALUE in sensor_values
+        assert all(v == SENSOR_NONE_VALUE for v in sensor_values)
+
+    def test_not_assigned_option_shows_count_of_sensorless_images(self):
+        recipe = FujifilmRecipeFactory()
+        ImageFactory.create_batch(3, fujifilm_recipe=recipe)
+
+        result = get_sidebar_filter_options({})
+
+        none_opt = next(o for o in result["sensors"]["options"] if o["value"] == SENSOR_NONE_VALUE)
+        assert none_opt["count"] == 3
+        assert none_opt["label"] == "Not assigned"
+
+    def test_named_sensor_appears_with_correct_count(self):
+        recipe = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe, sensor_names=("X-Trans IV",))
+        ImageFactory.create_batch(2, fujifilm_recipe=recipe)
+        other = FujifilmRecipeFactory()
+        ImageFactory(fujifilm_recipe=other)  # no sensor
+
+        result = get_sidebar_filter_options({})
+
+        sensor_opts = {o["value"]: o for o in result["sensors"]["options"]}
+        assert sensor_opts["X-Trans IV"]["count"] == 2
+        assert sensor_opts[SENSOR_NONE_VALUE]["count"] == 1
+
+    def test_active_sensor_filter_narrows_other_field_counts(self):
+        provia_recipe = FujifilmRecipeFactory(film_simulation="Provia")
+        velvia_recipe = FujifilmRecipeFactory(film_simulation="Velvia")
+        set_recipe_sensors(recipe=provia_recipe, sensor_names=("X-Trans IV",))
+        ImageFactory(fujifilm_recipe=provia_recipe)
+        ImageFactory(fujifilm_recipe=velvia_recipe)
+
+        result = get_sidebar_filter_options({"sensors": ["X-Trans IV"]})
+
+        film_available = {o["value"] for o in result["film_simulation"]["options"] if o["available"]}
+        assert "Provia" in film_available
+        assert "Velvia" not in film_available
+
+    def test_not_assigned_sorted_last_among_available_options(self):
+        recipe_a = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_a, sensor_names=("X-Trans IV",))
+        recipe_b = FujifilmRecipeFactory()  # no sensor
+        ImageFactory(fujifilm_recipe=recipe_a)
+        ImageFactory(fujifilm_recipe=recipe_b)
+
+        result = get_sidebar_filter_options({})
+
+        values = [o["value"] for o in result["sensors"]["options"] if o["available"]]
+        assert values[-1] == SENSOR_NONE_VALUE

--- a/tests/integration/domain/test_recipe_detail_query.py
+++ b/tests/integration/domain/test_recipe_detail_query.py
@@ -1,7 +1,9 @@
 import pytest
 
 from src.data import models
-from src.domain.recipes.queries import RecipeData, RecipeDetailContext, get_recipe_detail, get_recipe_gallery_data
+from src.domain.images.filter_queries import SENSOR_NONE_VALUE
+from src.domain.recipes.operations import set_recipe_sensors
+from src.domain.recipes.queries import RecipeData, RecipeDetailContext, get_recipe_detail, get_recipe_gallery_data, get_recipe_sidebar_filter_options
 from src.domain.recipes.constants import MONOCHROMATIC_FILM_SIMULATIONS
 from tests.factories import FujifilmRecipeFactory, ImageFactory
 
@@ -211,3 +213,102 @@ class TestGetRecipeGalleryDataCoverImage:
         recipe.set_cover_image(image_id=cover.pk)
 
         assert self._get_cover_id(recipe) == cover.pk
+
+
+@pytest.mark.django_db
+class TestGetRecipeSidebarFilterOptionsSensors:
+    def test_not_assigned_appears_for_sensorless_recipes(self):
+        FujifilmRecipeFactory()
+
+        result = get_recipe_sidebar_filter_options(active_filters={})
+
+        sensor_values = {o["value"] for o in result["sensors"]["options"]}
+        assert SENSOR_NONE_VALUE in sensor_values
+
+    def test_named_sensor_count_matches_recipes_with_that_sensor(self):
+        recipe_a = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_a, sensor_names=("X-Trans IV",))
+        recipe_b = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_b, sensor_names=("X-Trans IV",))
+        FujifilmRecipeFactory()  # no sensor
+
+        result = get_recipe_sidebar_filter_options(active_filters={})
+
+        sensor_opts = {o["value"]: o for o in result["sensors"]["options"]}
+        assert sensor_opts["X-Trans IV"]["count"] == 2
+        assert sensor_opts[SENSOR_NONE_VALUE]["count"] == 1
+
+    def test_active_sensor_filter_narrows_other_field_counts(self):
+        recipe_provia = FujifilmRecipeFactory(film_simulation="Provia")
+        recipe_velvia = FujifilmRecipeFactory(film_simulation="Velvia")
+        set_recipe_sensors(recipe=recipe_provia, sensor_names=("X-Trans IV",))
+
+        result = get_recipe_sidebar_filter_options(active_filters={"sensors": ["X-Trans IV"]})
+
+        film_available = {o["value"] for o in result["film_simulation"]["options"] if o["available"]}
+        assert "Provia" in film_available
+        assert "Velvia" not in film_available
+
+    def test_not_assigned_sorted_last_among_available_sensor_options(self):
+        recipe_a = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_a, sensor_names=("X-Trans IV",))
+        FujifilmRecipeFactory()  # no sensor
+
+        result = get_recipe_sidebar_filter_options(active_filters={})
+
+        values = [o["value"] for o in result["sensors"]["options"] if o["available"]]
+        assert values[-1] == SENSOR_NONE_VALUE
+
+
+@pytest.mark.django_db
+class TestGetRecipeGalleryDataSensorFilter:
+    def test_sensor_filter_none_returns_only_sensorless_recipes(self):
+        recipe_with_sensor = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_with_sensor, sensor_names=("X-Trans IV",))
+        recipe_without = FujifilmRecipeFactory()
+
+        result = get_recipe_gallery_data(
+            active_filters={"sensors": [SENSOR_NONE_VALUE]},
+            page_number=1,
+            page_size=50,
+        )
+
+        returned_ids = {r.id for r in result.page_obj.items}
+        assert recipe_without.pk in returned_ids
+        assert recipe_with_sensor.pk not in returned_ids
+
+    def test_sensor_filter_named_returns_only_matching_recipes(self):
+        recipe_xt4 = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_xt4, sensor_names=("X-Trans IV",))
+        recipe_gfx = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_gfx, sensor_names=("GFX",))
+        recipe_none = FujifilmRecipeFactory()
+
+        result = get_recipe_gallery_data(
+            active_filters={"sensors": ["X-Trans IV"]},
+            page_number=1,
+            page_size=50,
+        )
+
+        returned_ids = {r.id for r in result.page_obj.items}
+        assert recipe_xt4.pk in returned_ids
+        assert recipe_gfx.pk not in returned_ids
+        assert recipe_none.pk not in returned_ids
+
+    def test_sensor_filter_combined_named_and_none(self):
+        recipe_xt4 = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_xt4, sensor_names=("X-Trans IV",))
+        recipe_gfx = FujifilmRecipeFactory()
+        set_recipe_sensors(recipe=recipe_gfx, sensor_names=("GFX",))
+        recipe_none = FujifilmRecipeFactory()
+
+        result = get_recipe_gallery_data(
+            active_filters={"sensors": ["X-Trans IV", SENSOR_NONE_VALUE]},
+            page_number=1,
+            page_size=50,
+        )
+
+        returned_ids = {r.id for r in result.page_obj.items}
+        assert recipe_xt4.pk in returned_ids
+        assert recipe_none.pk in returned_ids
+        assert recipe_gfx.pk not in returned_ids


### PR DESCRIPTION
## Summary

- Add missing numeric filters (`highlight`, `shadow`, `color`, `sharpness`, `high_iso_nr`, `clarity`) to the recipes explorer sidebar. These were stored as `DecimalField` in the DB but missing from `RECIPE_FILTER_FIELDS`; a fix to the `is_numeric` check ensures correct null exclusion and numeric sort order for decimal values.
- Add a `sensor` filter to both the recipes explorer and images gallery sidebars. Sensors are a M2M relation and required special-casing: faceted counts use `distinct=True`, and the gallery filter applies the M2M lookup via a pk-subquery to avoid corrupting the `Count("images")` annotation. Recipes with no sensor assigned show as "Not assigned" (URL value: `none`).
- Sensor filter appears immediately below Film Simulation in both sidebars.

## Notes

- `RECIPE_FILTER_FIELDS` was intentionally left unchanged — sensors are handled as a special case in the filter functions rather than as a simple field lookup.
- Both view helpers (`_active_filters_from_request`, `_recipe_explorer_filters_from_request`) were updated to read `sensors` from the request, since it is not covered by the `RECIPE_FILTER_FIELDS` loop.
- The sidebar templates now use `{{ option.label|default:option.value }}` to allow a display label that differs from the URL parameter value.
